### PR TITLE
Source: Add `flights` into supported platform values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E typecheck \
 	-E unused \
 	-E varcheck
-VERSION := 0.1.16
+VERSION := 0.1.18
 .PHONY: test build
 
 help:

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -38,6 +38,7 @@ This Data Source allows you to look up existing Logtail Sources using their tabl
     - `dotnet`
     - `elasticsearch`
     - `filebeat`
+    - `flights`
     - `fluentbit`
     - `fluentd`
     - `fly_io`

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -32,6 +32,7 @@ This resource allows you to create, modify, and delete Logtail Sources. For more
     - `dotnet`
     - `elasticsearch`
     - `filebeat`
+    - `flights`
     - `fluentbit`
     - `fluentd`
     - `fly_io`

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -50,6 +50,7 @@ var sourceSchema = map[string]*schema.Schema{
     - **dotnet**
     - **elasticsearch**
     - **filebeat**
+    - **flights**
     - **fluentbit**
     - **fluentd**
     - **fly_io**


### PR DESCRIPTION
Manual `flights` demo source creation was enabled in L-2096