### PR TITLE
Add end-to-end tests for Terraform examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,67 @@
-on: [push, pull_request]
 name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
 jobs:
   test:
     strategy:
       matrix:
         go-version: [1.16.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Test
-      run: make test
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test ./...
+
+  e2e_test:
+    strategy:
+      matrix:
+        terraform-version: ["0.13", "0.14", "1.0", "1.8", "latest"]
+        config: [examples/basic, examples/advanced]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Add resources via Terraform
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="apply --auto-approve --input=false"
+        env:
+          LOGTAIL_API_TOKEN: ${{ secrets.LOGS_E2E_TEAM_TOKEN }}
+      - name: Plan resources via Terraform - must be empty
+        run: |
+          make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --input=false --out=tfplan"
+          make terraform CONFIGURATION="${{ matrix.config }}" ARGS="show --json tfplan > tfplan.json"
+          CHANGES="$(jq "[.resource_changes[]? | select(.change.actions != [\"no-op\"])] | length" "${{ matrix.config }}/tfplan.json")"
+          if [ "$CHANGES" == "0" ]; then
+            echo "No planned changes detected after first apply. Success!"
+          else
+            echo "$CHANGES planned changes detected after first apply. Failure!"
+            exit 1
+          fi
+        env:
+          LOGTAIL_API_TOKEN: ${{ secrets.LOGS_E2E_TEAM_TOKEN }}
+      - name: Destroy resources via Terraform
+        if: always()
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="destroy --auto-approve --input=false"
+        env:
+          LOGTAIL_API_TOKEN: ${{ secrets.LOGS_E2E_TEAM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
   e2e_test:
     strategy:
       matrix:
-        terraform-version: ["0.13", "0.14", "1.0", "1.8", "latest"]
+        terraform-version: ["0.13", "1.0", "1.8", "latest"]
         config: [examples/basic, examples/advanced]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -1,0 +1,9 @@
+provider "logtail" {
+  api_token = var.logtail_api_token
+}
+
+resource "logtail_source" "this" {
+  name             = "Terraform Advanced Source"
+  platform         = "http"
+  ingesting_paused = true
+}

--- a/examples/advanced/outputs.tf
+++ b/examples/advanced/outputs.tf
@@ -1,0 +1,3 @@
+output "logtail_source_token" {
+  value = logtail_source.this.token
+}

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -1,0 +1,9 @@
+variable "logtail_api_token" {
+  type        = string
+  description = <<EOF
+Logtail API Token
+(https://docs.logtail.com/api/getting-started#obtaining-an-api-token)
+EOF
+  # The value can be omitted if the LOGTAIL_API_TOKEN env var is set.
+  default = null
+}

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    logtail = {
+      source  = "BetterStackHQ/logtail"
+      version = ">= 0.1.0"
+    }
+  }
+}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -3,6 +3,6 @@ provider "logtail" {
 }
 
 resource "logtail_source" "this" {
-  name     = "Terraform Source"
+  name     = "Terraform Basic Source"
   platform = "http"
 }


### PR DESCRIPTION
Copied from https://github.com/BetterStackHQ/terraform-provider-better-uptime/pull/107

(except this provider works with Terraform as low as 0.13)