### PR TITLE
Update attributes in Source API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E typecheck \
 	-E unused \
 	-E varcheck
-VERSION := 0.1.18
+VERSION := 0.2.0
 .PHONY: test build
 
 help:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     logtail = {
       source = "BetterStackHQ/logtail"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -21,8 +21,12 @@ This Data Source allows you to look up existing Logtail Sources using their tabl
 
 ### Read-Only
 
+- **created_at** (String) The time when this monitor group was created.
 - **id** (String) The ID of this source.
 - **ingesting_paused** (Boolean) This property allows you to temporarily pause data ingesting for this source (e.g., when you are reaching your plan's usage quota and you want to prioritize some sources over others).
+- **live_tail_pattern** (String) Freeform text template for formatting Live tail output with columns wrapped in {column} brackets. Example: "PID: {message_json.pid} {level} {message}"
+- **logs_retention** (Number) Data retention for logs in days. There might be additional charges for longer retention.
+- **metrics_retention** (Number) Data retention for metrics in days. There might be additional charges for longer retention.
 - **name** (String) The name of this source.
 - **platform** (String) The platform of this source. This value can be set only when you're creating a new source. You can't update this value later. Valid values are:
     - `apache2`
@@ -68,6 +72,8 @@ This Data Source allows you to look up existing Logtail Sources using their tabl
     - `ubuntu`
     - `vector`
     - `vercel_integration`
+- **team_name** (String) Used to specify the team the resource should be created in when using global tokens.
 - **token** (String) The token of this source. This token is used to identify and route the data you will send to Logtail.
+- **updated_at** (String) The time when this monitor group was updated.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -66,11 +66,17 @@ This resource allows you to create, modify, and delete Logtail Sources. For more
 ### Optional
 
 - **ingesting_paused** (Boolean) This property allows you to temporarily pause data ingesting for this source (e.g., when you are reaching your plan's usage quota and you want to prioritize some sources over others).
+- **live_tail_pattern** (String) Freeform text template for formatting Live tail output with columns wrapped in {column} brackets. Example: "PID: {message_json.pid} {level} {message}"
+- **logs_retention** (Number) Data retention for logs in days. There might be additional charges for longer retention.
+- **metrics_retention** (Number) Data retention for metrics in days. There might be additional charges for longer retention.
+- **team_name** (String) Used to specify the team the resource should be created in when using global tokens.
 
 ### Read-Only
 
+- **created_at** (String) The time when this monitor group was created.
 - **id** (String) The ID of this source.
 - **table_name** (String) The table name generated for this source.
 - **token** (String) The token of this source. This token is used to identify and route the data you will send to Logtail.
+- **updated_at** (String) The time when this monitor group was updated.
 
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -3,7 +3,10 @@ provider "logtail" {
 }
 
 resource "logtail_source" "this" {
-  name             = "Terraform Advanced Source"
-  platform         = "http"
-  ingesting_paused = true
+  name              = "Terraform Advanced Source"
+  platform          = "http"
+  ingesting_paused  = true
+  live_tail_pattern = "{level} {message}"
+  logs_retention    = 7
+  metrics_retention = 14
 }

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -25,6 +25,7 @@ func newSourceDataSource() *schema.Resource {
 			cp.Computed = true
 			cp.Optional = false
 			cp.Required = false
+			cp.ValidateFunc = nil
 			cp.ValidateDiagFunc = nil
 			cp.Default = nil
 			cp.DefaultFunc = nil

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/url"
 	"reflect"
 	"strings"
@@ -15,9 +16,19 @@ import (
 var platformTypes = []string{"apache2", "aws_cloudwatch", "aws_ecs", "aws_elb", "aws_fargate", "cloudflare_logpush", "cloudflare_worker", "datadog_agent", "docker", "dokku", "dotnet", "elasticsearch", "filebeat", "fluentbit", "fluentd", "fly_io", "haproxy", "heroku", "http", "java", "javascript", "kubernetes", "logstash", "minio", "mongodb", "mysql", "nginx", "open_telemetry", "php", "postgresql", "prometheus", "python", "rabbitmq", "redis", "render", "rsyslog", "ruby", "syslog-ng", "traefik", "ubuntu", "vector", "vercel_integration"}
 
 var sourceSchema = map[string]*schema.Schema{
+	"team_name": {
+		Description: "Used to specify the team the resource should be created in when using global tokens.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     nil,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return d.Id() != ""
+		},
+	},
 	"id": {
 		Description: "The ID of this source.",
 		Type:        schema.TypeString,
+		Optional:    false,
 		Computed:    true,
 	},
 	"name": {
@@ -28,11 +39,13 @@ var sourceSchema = map[string]*schema.Schema{
 	"token": {
 		Description: "The token of this source. This token is used to identify and route the data you will send to Logtail.",
 		Type:        schema.TypeString,
+		Optional:    false,
 		Computed:    true,
 	},
 	"table_name": {
 		Description: "The table name generated for this source.",
 		Type:        schema.TypeString,
+		Optional:    false,
 		Computed:    true,
 	},
 	"platform": {
@@ -104,6 +117,39 @@ var sourceSchema = map[string]*schema.Schema{
 		Description: "This property allows you to temporarily pause data ingesting for this source (e.g., when you are reaching your plan's usage quota and you want to prioritize some sources over others).",
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
+	},
+	"logs_retention": {
+		Description:  "Data retention for logs in days. There might be additional charges for longer retention.",
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.IntBetween(1, 3652), // Must be between 1 day and 10 years
+	},
+	"metrics_retention": {
+		Description:  "Data retention for metrics in days. There might be additional charges for longer retention.",
+		Type:         schema.TypeInt,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.IntBetween(1, 3652), // Must be between 1 day and 10 years
+	},
+	"live_tail_pattern": {
+		Description: "Freeform text template for formatting Live tail output with columns wrapped in {column} brackets. Example: \"PID: {message_json.pid} {level} {message}\"",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+	},
+	"created_at": {
+		Description: "The time when this monitor group was created.",
+		Type:        schema.TypeString,
+		Optional:    false,
+		Computed:    true,
+	},
+	"updated_at": {
+		Description: "The time when this monitor group was updated.",
+		Type:        schema.TypeString,
+		Optional:    false,
+		Computed:    true,
 	},
 }
 
@@ -122,11 +168,17 @@ func newSourceResource() *schema.Resource {
 }
 
 type source struct {
-	Name            *string `json:"name,omitempty"`
-	Token           *string `json:"token,omitempty"`
-	TableName       *string `json:"table_name,omitempty"`
-	Platform        *string `json:"platform,omitempty"`
-	IngestingPaused *bool   `json:"ingesting_paused,omitempty"`
+	Name             *string `json:"name,omitempty"`
+	Token            *string `json:"token,omitempty"`
+	TableName        *string `json:"table_name,omitempty"`
+	Platform         *string `json:"platform,omitempty"`
+	IngestingPaused  *bool   `json:"ingesting_paused,omitempty"`
+	LogsRetention    *int    `json:"logs_retention,omitempty"`
+	MetricsRetention *int    `json:"metrics_retention,omitempty"`
+	LiveTailPattern  *string `json:"live_tail_pattern,omitempty"`
+	CreatedAt        *string `json:"created_at,omitempty"`
+	UpdatedAt        *string `json:"updated_at,omitempty"`
+	TeamName         *string `json:"team_name,omitempty"`
 }
 
 type sourceHTTPResponse struct {
@@ -149,6 +201,11 @@ func sourceRef(in *source) []struct {
 		{k: "table_name", v: &in.TableName},
 		{k: "platform", v: &in.Platform},
 		{k: "ingesting_paused", v: &in.IngestingPaused},
+		{k: "logs_retention", v: &in.LogsRetention},
+		{k: "metrics_retention", v: &in.MetricsRetention},
+		{k: "live_tail_pattern", v: &in.LiveTailPattern},
+		{k: "created_at", v: &in.CreatedAt},
+		{k: "updated_at", v: &in.UpdatedAt},
 	}
 }
 
@@ -157,6 +214,7 @@ func sourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	for _, e := range sourceRef(&in) {
 		load(d, e.k, e.v)
 	}
+	load(d, "team_name", &in.TeamName)
 	var out sourceHTTPResponse
 	if err := resourceCreate(ctx, meta, "/api/v1/sources", &in, &out); err != nil {
 		return err

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/url"
 	"reflect"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var platformTypes = []string{"apache2", "aws_cloudwatch", "aws_ecs", "aws_elb", "aws_fargate", "cloudflare_logpush", "cloudflare_worker", "datadog_agent", "docker", "dokku", "dotnet", "elasticsearch", "filebeat", "fluentbit", "fluentd", "fly_io", "haproxy", "heroku", "http", "java", "javascript", "kubernetes", "logstash", "minio", "mongodb", "mysql", "nginx", "open_telemetry", "php", "postgresql", "prometheus", "python", "rabbitmq", "redis", "render", "rsyslog", "ruby", "syslog-ng", "traefik", "ubuntu", "vector", "vercel_integration"}

--- a/internal/provider/resource_source_test.go
+++ b/internal/provider/resource_source_test.go
@@ -108,6 +108,9 @@ func TestResourceSource(t *testing.T) {
 				resource "logtail_source" "this" {
 					name              = "%s"
 					platform          = "%s"
+					logs_retention    = 14
+					metrics_retention = 60
+   					live_tail_pattern = "{level} {message}"
 					ingesting_paused  = true
 				}
 				`, name, platform),
@@ -119,7 +122,7 @@ func TestResourceSource(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
 				),
 			},
-			// Step 3 - make no changes, check plan is empty.
+			// Step 3 - make no changes, check plan is empty (omitted attributes are not controlled)
 			{
 				Config: fmt.Sprintf(`
 				provider "logtail" {
@@ -129,7 +132,6 @@ func TestResourceSource(t *testing.T) {
 				resource "logtail_source" "this" {
 					name             = "%s"
 					platform         = "%s"
-					ingesting_paused = true
 				}
 				`, name, platform),
 				PlanOnly: true,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 0.1.0"
+      version = ">= 0.2.0"
     }
   }
 }


### PR DESCRIPTION
Allows setting data retention and Live tail patterns for Sources.

Also adds support for global tokens and computed optional attributes (so some attributes, such as retention can be ignored by Terraform, and be configured in UI independently)

Planning on releasing as 0.2.0