### PR TITLE
Change URLs and naming from logtail.com to logs.betterstack.com

### DIFF
--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -3,12 +3,12 @@
 page_title: "logtail_source Data Source - terraform-provider-logtail"
 subcategory: ""
 description: |-
-  This Data Source allows you to look up existing Logtail Sources using their table name. The table name is shown on the Source settings page on Logtail.com or you can list all your existing sources via the Sources API https://docs.logtail.com/api/sources-api#get-sources.
+  This Data Source allows you to look up existing Sources using their table name. The table name is shown on the Source settings page on logs.betterstack.com or you can list all your existing sources via the Sources API https://betterstack.com/docs/logs/api/list-all-existing-sources/.
 ---
 
 # logtail_source (Data Source)
 
-This Data Source allows you to look up existing Logtail Sources using their table name. The table name is shown on the Source settings page on Logtail.com or you can list all your existing sources via the [Sources API](https://docs.logtail.com/api/sources-api#get-sources).
+This Data Source allows you to look up existing Sources using their table name. The table name is shown on the Source settings page on logs.betterstack.com or you can list all your existing sources via the [Sources API](https://betterstack.com/docs/logs/api/list-all-existing-sources/).
 
 
 
@@ -79,7 +79,7 @@ This Data Source allows you to look up existing Logtail Sources using their tabl
 - **scrape_request_headers** (List of Map of String) An array of request headers, each containing `name` and `value` fields.
 - **scrape_urls** (List of String) For scrape platform types, the set of urls to scrape.
 - **team_name** (String) Used to specify the team the resource should be created in when using global tokens.
-- **token** (String) The token of this source. This token is used to identify and route the data you will send to Logtail.
+- **token** (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - **updated_at** (String) The time when this monitor group was updated.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: |-
 
 # Better Stack Logs
 
-[Better Stack Logs](https://logs.betterstack.com) provider provides resources to interact with its [API](https://betterstack.com/docs/logs/api/getting-started/).
+[Better Stack Logs](https://logs.betterstack.com) provider provides resources to interact with the [Logs API](https://betterstack.com/docs/logs/api/getting-started/).
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
 layout: ""
-page_title: "Provider: Logtail"
+page_title: "Provider: logtail"
 description: |-
-  The Logtail provider.
+  The Better Stack Logs provider.
 ---
 
-# Logtail Provider
+# Better Stack Logs
 
-The [Logtail](https://logtail.com) provider provides resources to interact with the [Logtail API](https://docs.logtail.com/api/getting-started).
+[Better Stack Logs](https://logs.betterstack.com) provider provides resources to interact with its [API](https://betterstack.com/docs/logs/api/getting-started/).
 
 ## Installation
 
@@ -46,4 +46,4 @@ output "logtail_source_token" {
 
 ### Required
 
-- **api_token** (String, Sensitive) Logtail API Token. The value can be omitted if `LOGTAIL_API_TOKEN` environment variable is set. See https://docs.logtail.com/api/getting-started#obtaining-an-api-token on how to obtain the API token for your team.
+- **api_token** (String, Sensitive) Better Stack Logs API Token. The value can be omitted if `LOGTAIL_API_TOKEN` environment variable is set. See https://betterstack.com/docs/logs/api/getting-started/#get-an-logs-api-token on how to obtain the API token for your team.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -3,12 +3,12 @@
 page_title: "logtail_source Resource - terraform-provider-logtail"
 subcategory: ""
 description: |-
-  This resource allows you to create, modify, and delete Logtail Sources. For more information about the Sources API check https://docs.logtail.com/api/sources-api
+  This resource allows you to create, modify, and delete your Sources. For more information about the Sources API check https://betterstack.com/docs/logs/api/list-all-existing-sources/
 ---
 
 # logtail_source (Resource)
 
-This resource allows you to create, modify, and delete Logtail Sources. For more information about the Sources API check https://docs.logtail.com/api/sources-api
+This resource allows you to create, modify, and delete your Sources. For more information about the Sources API check https://betterstack.com/docs/logs/api/list-all-existing-sources/
 
 
 
@@ -82,7 +82,7 @@ This resource allows you to create, modify, and delete Logtail Sources. For more
 - **created_at** (String) The time when this monitor group was created.
 - **id** (String) The ID of this source.
 - **table_name** (String) The table name generated for this source.
-- **token** (String) The token of this source. This token is used to identify and route the data you will send to Logtail.
+- **token** (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - **updated_at** (String) The time when this monitor group was updated.
 
 

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -1,8 +1,8 @@
 variable "logtail_api_token" {
   type        = string
   description = <<EOF
-Logtail API Token
-(https://docs.logtail.com/api/getting-started#obtaining-an-api-token)
+Better Stack Logs API Token
+(https://betterstack.com/docs/logs/api/getting-started/#get-an-logs-api-token)
 EOF
   # The value can be omitted if the LOGTAIL_API_TOKEN env var is set.
   default = null

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -2,7 +2,7 @@ variable "logtail_api_token" {
   type        = string
   description = <<EOF
 Logtail API Token
-(https://docs.logtail.com/api/getting-started#obtaining-an-api-token)
+(https://betterstack.com/docs/logs/api/getting-started/#get-an-logs-api-token)
 EOF
   # The value can be omitted if the LOGTAIL_API_TOKEN env var is set.
   default = null

--- a/examples/scrape/variables.tf
+++ b/examples/scrape/variables.tf
@@ -1,8 +1,8 @@
 variable "logtail_api_token" {
   type        = string
   description = <<EOF
-Logtail API Token
-(https://docs.logtail.com/api/getting-started#obtaining-an-api-token)
+Better Stack Logs API Token
+(https://betterstack.com/docs/logs/api/getting-started/#get-an-logs-api-token)
 EOF
   # The value can be omitted if the LOGTAIL_API_TOKEN env var is set.
   default = null

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -35,7 +35,7 @@ func newSourceDataSource() *schema.Resource {
 	}
 	return &schema.Resource{
 		ReadContext: sourceLookup,
-		Description: "This Data Source allows you to look up existing Logtail Sources using their table name. The table name is shown on the Source settings page on Logtail.com or you can list all your existing sources via the [Sources API](https://docs.logtail.com/api/sources-api#get-sources).",
+		Description: "This Data Source allows you to look up existing Sources using their table name. The table name is shown on the Source settings page on logs.betterstack.com or you can list all your existing sources via the [Sources API](https://betterstack.com/docs/logs/api/list-all-existing-sources/).",
 		Schema:      s,
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,7 +30,7 @@ func WithVersion(v string) Option {
 
 func New(opts ...Option) *schema.Provider {
 	spec := provider{
-		url: "https://logtail.com",
+		url: "https://logs.betterstack.com",
 	}
 	for _, opt := range opts {
 		opt(&spec)
@@ -42,7 +42,7 @@ func New(opts ...Option) *schema.Provider {
 				Sensitive:   true,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("LOGTAIL_API_TOKEN", nil),
-				Description: "Logtail API Token. The value can be omitted if `LOGTAIL_API_TOKEN` environment variable is set. See https://docs.logtail.com/api/getting-started#obtaining-an-api-token on how to obtain the API token for your team.",
+				Description: "Better Stack Logs API Token. The value can be omitted if `LOGTAIL_API_TOKEN` environment variable is set. See https://betterstack.com/docs/logs/api/getting-started/#get-an-logs-api-token on how to obtain the API token for your team.",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -37,7 +37,7 @@ var sourceSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"token": {
-		Description: "The token of this source. This token is used to identify and route the data you will send to Logtail.",
+		Description: "The token of this source. This token is used to identify and route the data you will send to Better Stack.",
 		Type:        schema.TypeString,
 		Optional:    false,
 		Computed:    true,
@@ -199,7 +199,7 @@ func newSourceResource() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: validateRequestHeaders,
-		Description:   "This resource allows you to create, modify, and delete Logtail Sources. For more information about the Sources API check https://docs.logtail.com/api/sources-api",
+		Description:   "This resource allows you to create, modify, and delete your Sources. For more information about the Sources API check https://betterstack.com/docs/logs/api/list-all-existing-sources/",
 		Schema:        sourceSchema,
 	}
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,13 +1,13 @@
 ---
 layout: ""
-page_title: "Provider: Logtail"
+page_title: "Provider: logtail"
 description: |-
-  The Logtail provider.
+  The Better Stack Logs provider.
 ---
 
-# Logtail Provider
+# Better Stack Logs
 
-The [Logtail](https://logtail.com) provider provides resources to interact with the [Logtail API](https://docs.logtail.com/api/getting-started).
+[Better Stack Logs](https://logs.betterstack.com) provider provides resources to interact with its [API](https://betterstack.com/docs/logs/api/getting-started/).
 
 ## Installation
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # Better Stack Logs
 
-[Better Stack Logs](https://logs.betterstack.com) provider provides resources to interact with its [API](https://betterstack.com/docs/logs/api/getting-started/).
+[Better Stack Logs](https://logs.betterstack.com) provider provides resources to interact with the [Logs API](https://betterstack.com/docs/logs/api/getting-started/).
 
 ## Installation
 


### PR DESCRIPTION
Changing links and copy after the rename Logtail -> Better Stack Logs