### PR TITLE
L-3189 [sources] Add Go and Erlang

### DIFF
--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -41,11 +41,13 @@ This Data Source allows you to look up existing Sources using their table name. 
     - `dokku`
     - `dotnet`
     - `elasticsearch`
+    - `erlang`
     - `filebeat`
     - `flights`
     - `fluentbit`
     - `fluentd`
     - `fly_io`
+    - `go`
     - `haproxy`
     - `heroku`
     - `http`

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -31,11 +31,13 @@ This resource allows you to create, modify, and delete your Sources. For more in
     - `dokku`
     - `dotnet`
     - `elasticsearch`
+    - `erlang`
     - `filebeat`
     - `flights`
     - `fluentbit`
     - `fluentd`
     - `fly_io`
+    - `go`
     - `haproxy`
     - `heroku`
     - `http`

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var platformTypes = []string{"apache2", "aws_cloudwatch", "aws_ecs", "aws_elb", "aws_fargate", "cloudflare_logpush", "cloudflare_worker", "datadog_agent", "docker", "dokku", "dotnet", "elasticsearch", "filebeat", "fluentbit", "fluentd", "fly_io", "haproxy", "heroku", "http", "java", "javascript", "kubernetes", "logstash", "minio", "mongodb", "mysql", "nginx", "open_telemetry", "php", "postgresql", "prometheus", "prometheus_scrape", "python", "rabbitmq", "redis", "render", "rsyslog", "ruby", "syslog-ng", "traefik", "ubuntu", "vector", "vercel_integration"}
+var platformTypes = []string{"apache2", "aws_cloudwatch", "aws_ecs", "aws_elb", "aws_fargate", "cloudflare_logpush", "cloudflare_worker", "datadog_agent", "docker", "dokku", "dotnet", "elasticsearch", "erlang", "filebeat", "fluentbit", "fluentd", "fly_io", "go", "haproxy", "heroku", "http", "java", "javascript", "kubernetes", "logstash", "minio", "mongodb", "mysql", "nginx", "open_telemetry", "php", "postgresql", "prometheus", "prometheus_scrape", "python", "rabbitmq", "redis", "render", "rsyslog", "ruby", "syslog-ng", "traefik", "ubuntu", "vector", "vercel_integration"}
 
 var sourceSchema = map[string]*schema.Schema{
 	"team_name": {
@@ -62,11 +62,13 @@ var sourceSchema = map[string]*schema.Schema{
     - **dokku**
     - **dotnet**
     - **elasticsearch**
+    - **erlang**
     - **filebeat**
     - **flights**
     - **fluentbit**
     - **fluentd**
     - **fly_io**
+    - **go**
     - **haproxy**
     - **heroku**
     - **http**


### PR DESCRIPTION
Adds `go` and `erlang` as new sources. We now have guides for [Go](https://betterstack.com/docs/logs/go/) and [Erlang](https://betterstack.com/docs/logs/erlang/) using community libs.

Related to https://github.com/BetterStackHQ/logtail/pull/8246

Will release this as a new patch version.