### PR TITLE
[T-5361] Add support for optional resource_group_id on source resource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,26 @@ on:
       - main
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23.x'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 'latest'
       - run: make lint
   check_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23.x'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 'latest'
       - name: Generate docs automatically
         run: make gen
       - name: Check no versioned file has been updated

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.4
+VERSION := 0.5
 .PHONY: test build
 
 help:

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -79,6 +79,7 @@ This Data Source allows you to look up existing Sources using their table name. 
     - `ubuntu`
     - `vector`
     - `vercel_integration`
+- `resource_group_id` (Number) The ID of the resource group this source belongs to.
 - `scrape_frequency_secs` (Number) For scrape platform types, how often to scrape the URLs.
 - `scrape_request_basic_auth_password` (String, Sensitive) Basic auth password for scraping.
 - `scrape_request_basic_auth_user` (String) Basic auth username for scraping.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -75,6 +75,7 @@ This resource allows you to create, modify, and delete your Sources. For more in
 - `live_tail_pattern` (String) Freeform text template for formatting Live tail output with columns wrapped in {column} brackets. Example: "PID: {message_json.pid} {level} {message}"
 - `logs_retention` (Number) Data retention for logs in days. There might be additional charges for longer retention.
 - `metrics_retention` (Number) Data retention for metrics in days. There might be additional charges for longer retention.
+- `resource_group_id` (Number) The ID of the resource group this source belongs to.
 - `scrape_frequency_secs` (Number) For scrape platform types, how often to scrape the URLs.
 - `scrape_request_basic_auth_password` (String, Sensitive) Basic auth password for scraping.
 - `scrape_request_basic_auth_user` (String) Basic auth username for scraping.

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -203,6 +203,11 @@ var sourceSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Computed:    true,
 	},
+	"resource_group_id": {
+		Description: "The ID of the resource group this source belongs to.",
+		Type:        schema.TypeInt,
+		Optional:    true,
+	},
 }
 
 func newSourceResource() *schema.Resource {
@@ -239,6 +244,7 @@ type source struct {
 	ScrapeRequestBasicAuthUser     *string                   `json:"scrape_request_basic_auth_user,omitempty"`
 	ScrapeRequestBasicAuthPassword *string                   `json:"scrape_request_basic_auth_password,omitempty"`
 	DataRegion                     *string                   `json:"data_region,omitempty"`
+	ResourceGroupID                *int                      `json:"resource_group_id,omitempty"`
 }
 
 type sourceHTTPResponse struct {
@@ -273,6 +279,7 @@ func sourceRef(in *source) []struct {
 		{k: "scrape_request_basic_auth_user", v: &in.ScrapeRequestBasicAuthUser},
 		{k: "scrape_request_basic_auth_password", v: &in.ScrapeRequestBasicAuthPassword},
 		{k: "data_region", v: &in.DataRegion},
+		{k: "resource_group_id", v: &in.ResourceGroupID},
 	}
 }
 

--- a/internal/provider/resource_source_test.go
+++ b/internal/provider/resource_source_test.go
@@ -93,6 +93,7 @@ func TestResourceSource(t *testing.T) {
 					name             = "%s"
 					platform         = "%s"
 					data_region      = "eu-hel-1-legacy"
+					resource_group_id = 123
 				}
 				`, name, platform),
 				Check: resource.ComposeTestCheckFunc(
@@ -102,6 +103,7 @@ func TestResourceSource(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
 					resource.TestCheckResourceAttr("logtail_source.this", "ingesting_host", "in.logs.betterstack.com"),
 					resource.TestCheckResourceAttr("logtail_source.this", "data_region", "eu-hel-1-legacy"),
+					resource.TestCheckResourceAttr("logtail_source.this", "resource_group_id", "123"),
 				),
 			},
 			// Step 2 - update.
@@ -118,6 +120,7 @@ func TestResourceSource(t *testing.T) {
 					metrics_retention = 60
    					live_tail_pattern = "{level} {message}"
 					ingesting_paused  = true
+					resource_group_id = 456
 				}
 				`, name, platform),
 				Check: resource.ComposeTestCheckFunc(
@@ -128,6 +131,7 @@ func TestResourceSource(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
 					resource.TestCheckResourceAttr("logtail_source.this", "ingesting_host", "in.logs.betterstack.com"),
 					resource.TestCheckResourceAttr("logtail_source.this", "data_region", "eu-hel-1-legacy"),
+					resource.TestCheckResourceAttr("logtail_source.this", "resource_group_id", "456"),
 				),
 			},
 			// Step 3 - make no changes, check plan is empty (omitted attributes are not controlled)
@@ -140,6 +144,7 @@ func TestResourceSource(t *testing.T) {
 				resource "logtail_source" "this" {
 					name             = "%s"
 					platform         = "%s"
+					resource_group_id = 456
 				}
 				`, name, platform),
 				PlanOnly: true,


### PR DESCRIPTION
This adds support for the optional field `resource_group_id` that is now available via the API.

Also fixed gh actions using unsupported ubuntu versions 