### PR TITLE
T-7696 Allow controlling VRL transformations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.6.1
+VERSION := 0.6.2
 .PHONY: test build
 
 help:

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -89,6 +89,7 @@ This Data Source allows you to look up existing Sources using their table name. 
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `token` (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this monitor group was updated.
+- `vrl_transformation` (String) The VRL code that's used to transform events. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
 
 <a id="nestedatt--custom_bucket"></a>
 ### Nested Schema for `custom_bucket`

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -83,6 +83,7 @@ This resource allows you to create, modify, and delete your Sources. For more in
 - `scrape_urls` (List of String) For scrape platform types, the set of urls to scrape.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `vrl_transformation` (String) The VRL code that's used to transform events. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
 
 ### Read-Only
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -7,13 +7,18 @@ resource "logtail_source_group" "group" {
 }
 
 resource "logtail_source" "this" {
-  name              = "Terraform Advanced Source"
-  platform          = "http"
-  ingesting_paused  = true
-  live_tail_pattern = "{level} {message}"
-  logs_retention    = 60
-  metrics_retention = 90
-  source_group_id   = logtail_source_group.group.id
+  name               = "Terraform Advanced Source"
+  platform           = "http"
+  ingesting_paused   = true
+  live_tail_pattern  = "{level} {message}"
+  logs_retention     = 60
+  metrics_retention  = 90
+  vrl_transformation = <<EOT
+    # Expected msg format: [svc:router] GET /api/health succeeded in 12.345ms
+    .duration_ms = extract(.message, "in (\d+(?:\.\d+)?)ms")
+    .service_name = extract(.message, "\[svc:([a-zA-Z_-])\]")
+    EOT
+  source_group_id    = logtail_source_group.group.id
 }
 
 resource "logtail_metric" "duration_ms" {

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -15,8 +15,11 @@ resource "logtail_source" "this" {
   metrics_retention  = 90
   vrl_transformation = <<EOT
     # Expected msg format: [svc:router] GET /api/health succeeded in 12.345ms
-    .duration_ms = extract(.message, "in (\d+(?:\.\d+)?)ms")
-    .service_name = extract(.message, "\[svc:([a-zA-Z_-])\]")
+    parsed, err = parse_regex(.message, r'\[svc:(?P<service>[a-zA-Z_-]+)\] .* in (?P<duration>\d+(?:\.\d+)?)ms')
+    if (err == null) {
+        .service_name = parsed.service
+        .duration_ms = to_float!(parsed.duration)
+    }
     EOT
   source_group_id    = logtail_source_group.group.id
 }

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -14,13 +14,13 @@ resource "logtail_source" "this" {
   logs_retention     = 60
   metrics_retention  = 90
   vrl_transformation = <<EOT
-    # Expected msg format: [svc:router] GET /api/health succeeded in 12.345ms
-    parsed, err = parse_regex(.message, r'\[svc:(?P<service>[a-zA-Z_-]+)\] .* in (?P<duration>\d+(?:\.\d+)?)ms')
-    if (err == null) {
-        .service_name = parsed.service
-        .duration_ms = to_float!(parsed.duration)
-    }
-    EOT
+# Expected msg format: [svc:router] GET /api/health succeeded in 12.345ms
+parsed, err = parse_regex(.message, r'\[svc:(?P<service>[a-zA-Z_-]+)\] .* in (?P<duration>\d+(?:\.\d+)?)ms')
+if (err == null) {
+    .service_name = parsed.service
+    .duration_ms = to_float!(parsed.duration)
+}
+EOT
   source_group_id    = logtail_source_group.group.id
 }
 

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 0.6.1"
+      version = ">= 0.6.2"
     }
   }
 }

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -396,20 +396,6 @@ func sourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func sourceCopyAttrs(d *schema.ResourceData, in *source) diag.Diagnostics {
 	var derr diag.Diagnostics
 	for _, e := range sourceRef(in) {
-		// Special handling for vrl_transformation
-		if e.k == "vrl_transformation" && in.VrlTransformation != nil {
-			// Remove the API-added trailing "\n." if the original was empty or didn't have it
-			vrl := *in.VrlTransformation
-			if vrl == "\n." || vrl == "." {
-				// API returns "\n." for empty VRL, set to empty string
-				if err := d.Set(e.k, ""); err != nil {
-					derr = append(derr, diag.FromErr(err)[0])
-				}
-				continue
-			}
-			// Otherwise use the value as-is
-		}
-
 		if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}


### PR DESCRIPTION
API transforms the `vrl_transformation` upon receiving it, so there is a bit of normalization in place to ignore such differences.

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/e7960033-a05e-4d3d-9ee3-29e7926bd298" />
