### PR TITLE
[metric] Remove unused team_name attribute

### DIFF
--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -25,5 +25,4 @@ This Data Source allows you to look up existing Metrics using their name. You ca
 - `aggregations` (List of String) The list of aggregations to perform on the metric.
 - `id` (String) The ID of this metric.
 - `sql_expression` (String) The SQL expression used to extract the metric value.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `type` (String) The type of the metric.

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -23,10 +23,6 @@ This resource allows you to create and delete Metrics.
 - `sql_expression` (String) The SQL expression used to extract the metric value.
 - `type` (String) The type of the metric.
 
-### Optional
-
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
-
 ### Read-Only
 
 - `id` (String) The ID of this metric.

--- a/internal/provider/resource_metric.go
+++ b/internal/provider/resource_metric.go
@@ -59,7 +59,6 @@ func newMetricResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: metricCreate,
 		ReadContext:   metricLookup,
-		UpdateContext: metricUpdate,
 		DeleteContext: metricDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -182,10 +181,6 @@ func metricCopyAttrs(d *schema.ResourceData, in *metric) diag.Diagnostics {
 		}
 	}
 	return derr
-}
-
-func metricUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return diag.Errorf("Metrics cannot be updated.")
 }
 
 func metricDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_metric.go
+++ b/internal/provider/resource_metric.go
@@ -15,15 +15,6 @@ import (
 )
 
 var metricSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
 	"id": {
 		Description: "The ID of this metric.",
 		Type:        schema.TypeString,

--- a/internal/provider/resource_warehouse_time_series.go
+++ b/internal/provider/resource_warehouse_time_series.go
@@ -37,6 +37,7 @@ var warehouseTimeSeriesSchema = map[string]*schema.Schema{
 		Description: "The name of the time series. Must contain only letters, numbers, and underscores.",
 		Type:        schema.TypeString,
 		Required:    true,
+		ForceNew:    true,
 	},
 	"type": {
 		Description: `The data type of the time series. Valid types are: ` + "`string`, `string_low_cardinality`, `int64_delta`, `int64`, `uint64_delta`, `uint64`, `float64_delta`, `datetime64_delta`, `boolean`, `array_bfloat16`, `array_float32`",
@@ -64,11 +65,13 @@ var warehouseTimeSeriesSchema = map[string]*schema.Schema{
 		Description: "The SQL expression used to compute the time series. For example `JSONExtract(raw, 'response_time', 'Nullable(Float64)')`.",
 		Type:        schema.TypeString,
 		Required:    true,
+		ForceNew:    true,
 	},
 	"aggregations": {
 		Description: "An array of aggregation functions (e.g., `avg`, `min`, `max`). If omitted, no aggregations are applied.",
 		Type:        schema.TypeList,
 		Optional:    true,
+		ForceNew:    true,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},
@@ -77,17 +80,20 @@ var warehouseTimeSeriesSchema = map[string]*schema.Schema{
 		Description: "The type of vector index to apply (e.g., `vector_similarity`). Only applicable for vector types (`array_bfloat16`, `array_float32`).",
 		Type:        schema.TypeString,
 		Optional:    true,
+		ForceNew:    true,
 	},
 	"vector_dimension": {
 		Description:  "The vector dimension if `expression_index` is `vector_similarity` (e.g., `512`). Supported values: 256, 384, 512, 768, 1024, 1536, 3072, 4096, 10752.",
 		Type:         schema.TypeInt,
 		Optional:     true,
+		ForceNew:     true,
 		ValidateFunc: validation.IntInSlice([]int{256, 384, 512, 768, 1024, 1536, 3072, 4096, 10752}),
 	},
 	"vector_distance_function": {
 		Description:  "The distance function to use for vector similarity (e.g., `cosine`, `l2`).",
 		Type:         schema.TypeString,
 		Optional:     true,
+		ForceNew:     true,
 		ValidateFunc: validation.StringInSlice([]string{"cosine", "l2"}, false),
 	},
 }
@@ -96,7 +102,6 @@ func newWarehouseTimeSeriesResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: warehouseTimeSeriesCreate,
 		ReadContext:   warehouseTimeSeriesRead,
-		UpdateContext: warehouseTimeSeriesUpdate,
 		DeleteContext: warehouseTimeSeriesDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -224,10 +229,6 @@ func warehouseTimeSeriesCopyAttrs(d *schema.ResourceData, in *warehouseTimeSerie
 	}
 
 	return derr
-}
-
-func warehouseTimeSeriesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return diag.Errorf("Time series cannot be updated.")
 }
 
 func warehouseTimeSeriesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
The `team_name` attribute is unused in metric resource, since it's tightly linked to a source already - no need to specify team even when creating the resource.