### PR TITLE
Add missing team_id to source output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.7.1
+VERSION := 0.7.3
 .PHONY: test build
 
 help:

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -87,6 +87,7 @@ This Data Source allows you to look up existing Sources using their table name. 
 - `scrape_request_headers` (List of Map of String) An array of request headers, each containing `name` and `value` fields.
 - `scrape_urls` (List of String) For scrape platform types, the set of urls to scrape.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
+- `team_id` (Number) The team ID for this resource. To be used in tablenames to query.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `token` (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this monitor group was updated.

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -87,7 +87,7 @@ This Data Source allows you to look up existing Sources using their table name. 
 - `scrape_request_headers` (List of Map of String) An array of request headers, each containing `name` and `value` fields.
 - `scrape_urls` (List of String) For scrape platform types, the set of urls to scrape.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
-- `team_id` (Number) The team ID for this resource. To be used in tablenames to query.
+- `team_id` (String) The team ID for this resource. Can be used with table_name in [Query API](https://betterstack.com/docs/logs/query-api/connect-remotely/).
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `token` (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this monitor group was updated.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -92,7 +92,7 @@ This resource allows you to create, modify, and delete your Sources. For more in
 - `id` (String) The ID of this source.
 - `ingesting_host` (String) The host where the logs or metrics should be sent. See [documentation](https://betterstack.com/docs/logs/start/) for your specific source platform for details.
 - `table_name` (String) The table name generated for this source.
-- `team_id` (Number) The team ID for this resource. To be used in tablenames to query.
+- `team_id` (String) The team ID for this resource. Can be used with table_name in [Query API](https://betterstack.com/docs/logs/query-api/connect-remotely/).
 - `token` (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this monitor group was updated.
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -92,6 +92,7 @@ This resource allows you to create, modify, and delete your Sources. For more in
 - `id` (String) The ID of this source.
 - `ingesting_host` (String) The host where the logs or metrics should be sent. See [documentation](https://betterstack.com/docs/logs/start/) for your specific source platform for details.
 - `table_name` (String) The table name generated for this source.
+- `team_id` (Number) The team ID for this resource. To be used in tablenames to query.
 - `token` (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this monitor group was updated.
 

--- a/examples/connection/outputs.tf
+++ b/examples/connection/outputs.tf
@@ -18,3 +18,8 @@ output "data_sources" {
   description = "Data sources of the connection"
   value       = logtail_connection.example.data_sources
 }
+
+output "data_source_s3_constructed" {
+  description = "Data source for S3 constructed from my_source directly"
+  value       = "t${logtail_source.my_source.team_id}_${logtail_source.my_source.table_name}_s3"
+}

--- a/examples/connection/versions.tf
+++ b/examples/connection/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "betterstackhq/logtail"
-      version = "0.7.1"
+      version = "0.7.3"
     }
   }
 }

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -24,9 +24,9 @@ func TestDataMonitor(t *testing.T) {
 
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=1":
-			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name":"Test Source","token":"token123","table_name":"abc","platform":"ubuntu"}}],"pagination":{"next":"..."}}`))
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name":"Test Source","token":"token123","table_name":"abc", "team_id": 123456,"platform":"ubuntu"}}],"pagination":{"next":"..."}}`))
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=2":
-			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"name":"Other Test Source","token":"token456","table_name":"def","platform":"ubuntu"}}],"pagination":{"next":null}}`))
+			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"name":"Other Test Source","token":"token456","table_name":"def", "team_id": 123456,"platform":"ubuntu"}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
 		}
@@ -57,6 +57,7 @@ func TestDataMonitor(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.logtail_source.this", "id"),
 					resource.TestCheckResourceAttr("data.logtail_source.this", "table_name", table_name),
 					resource.TestCheckResourceAttr("data.logtail_source.this", "platform", "ubuntu"),
+					resource.TestCheckResourceAttr("data.logtail_source.this", "team_id", "123456"),
 				),
 			},
 		},

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -25,6 +25,12 @@ var sourceSchema = map[string]*schema.Schema{
 			return d.Id() != ""
 		},
 	},
+	"team_id": {
+		Description: "The team ID for this resource. To be used in tablenames to query.",
+		Type:        schema.TypeInt,
+		Optional:    false,
+		Computed:    true,
+	},
 	"id": {
 		Description: "The ID of this source.",
 		Type:        schema.TypeString,
@@ -303,6 +309,7 @@ type sourceCustomBucket struct {
 type source struct {
 	Name                           *string                   `json:"name,omitempty"`
 	Token                          *string                   `json:"token,omitempty"`
+	TeamId                         *int                      `json:"team_id,omitempty"`
 	TableName                      *string                   `json:"table_name,omitempty"`
 	Platform                       *string                   `json:"platform,omitempty"`
 	IngestingHost                  *string                   `json:"ingesting_host,omitempty"`
@@ -341,6 +348,7 @@ func sourceRef(in *source) []struct {
 	}{
 		{k: "name", v: &in.Name},
 		{k: "token", v: &in.Token},
+		{k: "team_id", v: &in.TeamId},
 		{k: "table_name", v: &in.TableName},
 		{k: "platform", v: &in.Platform},
 		{k: "ingesting_host", v: &in.IngestingHost},

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -26,8 +26,8 @@ var sourceSchema = map[string]*schema.Schema{
 		},
 	},
 	"team_id": {
-		Description: "The team ID for this resource. To be used in tablenames to query.",
-		Type:        schema.TypeInt,
+		Description: "The team ID for this resource. Can be used with table_name in [Query API](https://betterstack.com/docs/logs/query-api/connect-remotely/).",
+		Type:        schema.TypeString,
 		Optional:    false,
 		Computed:    true,
 	},
@@ -309,7 +309,7 @@ type sourceCustomBucket struct {
 type source struct {
 	Name                           *string                   `json:"name,omitempty"`
 	Token                          *string                   `json:"token,omitempty"`
-	TeamId                         *int                      `json:"team_id,omitempty"`
+	TeamId                         *StringOrInt              `json:"team_id,omitempty"`
 	TableName                      *string                   `json:"table_name,omitempty"`
 	Platform                       *string                   `json:"platform,omitempty"`
 	IngestingHost                  *string                   `json:"ingesting_host,omitempty"`
@@ -372,7 +372,11 @@ func sourceRef(in *source) []struct {
 func sourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in source
 	for _, e := range sourceRef(&in) {
-		load(d, e.k, e.v)
+		if e.k == "team_id" {
+			in.TeamId = StringOrIntFromResourceData(d, e.k)
+		} else {
+			load(d, e.k, e.v)
+		}
 	}
 
 	load(d, "team_name", &in.TeamName)
@@ -417,6 +421,10 @@ func sourceCopyAttrs(d *schema.ResourceData, in *source) diag.Diagnostics {
 			// Don't update data region from API if it's already set - data_region can't change
 			// This prevents e.g. "germany" being overwritten by "eu-nbg-2"
 			continue
+		} else if e.k == "team_id" {
+			if err := SetStringOrIntResourceData(d, "team_id", in.TeamId); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		} else if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}
@@ -458,7 +466,11 @@ func sourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	var in source
 	for _, e := range sourceRef(&in) {
 		if d.HasChange(e.k) {
-			load(d, e.k, e.v)
+			if e.k == "team_id" {
+				in.TeamId = StringOrIntFromResourceData(d, e.k)
+			} else {
+				load(d, e.k, e.v)
+			}
 		}
 	}
 	return resourceUpdate(ctx, meta, fmt.Sprintf("/api/v1/sources/%s", url.PathEscape(d.Id())), &in)

--- a/internal/provider/resource_source_test.go
+++ b/internal/provider/resource_source_test.go
@@ -109,6 +109,7 @@ func TestResourceSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("logtail_source.this", "id"),
 					resource.TestCheckResourceAttr("logtail_source.this", "name", name),
+					resource.TestCheckResourceAttr("logtail_source.this", "team_id", "123456"),
 					resource.TestCheckResourceAttr("logtail_source.this", "platform", platform),
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
 					resource.TestCheckResourceAttr("logtail_source.this", "ingesting_host", "in.logs.betterstack.com"),
@@ -136,6 +137,7 @@ func TestResourceSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("logtail_source.this", "id"),
 					resource.TestCheckResourceAttr("logtail_source.this", "name", name),
+					resource.TestCheckResourceAttr("logtail_source.this", "team_id", "123456"),
 					resource.TestCheckResourceAttr("logtail_source.this", "platform", platform),
 					resource.TestCheckResourceAttr("logtail_source.this", "ingesting_paused", "true"),
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
@@ -195,6 +197,7 @@ func TestResourceSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("logtail_source.this", "id"),
 					resource.TestCheckResourceAttr("logtail_source.this", "name", name),
+					resource.TestCheckResourceAttr("logtail_source.this", "team_id", "123456"),
 					resource.TestCheckResourceAttr("logtail_source.this", "platform", platform_scrape),
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
 					resource.TestCheckResourceAttr("logtail_source.this", "scrape_urls.#", "2"),
@@ -230,6 +233,7 @@ func TestResourceSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("logtail_source.this", "id"),
 					resource.TestCheckResourceAttr("logtail_source.this", "name", name),
+					resource.TestCheckResourceAttr("logtail_source.this", "team_id", "123456"),
 					resource.TestCheckResourceAttr("logtail_source.this", "platform", platform_scrape),
 					resource.TestCheckResourceAttr("logtail_source.this", "ingesting_paused", "true"),
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
@@ -572,6 +576,7 @@ func TestResourceSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("logtail_source.this", "id"),
 					resource.TestCheckResourceAttr("logtail_source.this", "name", name),
+					resource.TestCheckResourceAttr("logtail_source.this", "team_id", "123456"),
 					resource.TestCheckResourceAttr("logtail_source.this", "platform", platform),
 					resource.TestCheckResourceAttr("logtail_source.this", "custom_bucket.#", "1"),
 					resource.TestCheckResourceAttr("logtail_source.this", "custom_bucket.0.name", "my-test-bucket"),

--- a/internal/provider/resource_source_test.go
+++ b/internal/provider/resource_source_test.go
@@ -36,6 +36,7 @@ func TestResourceSource(t *testing.T) {
 			body = inject(t, body, "token", "generated_by_logtail")
 			body = inject(t, body, "ingesting_host", "in.logs.betterstack.com")
 			body = inject(t, body, "table_name", "test_source")
+			body = inject(t, body, "team_id", 123456)
 
 			// Handle custom_bucket - remove secret_access_key from response as API doesn't return it
 			body = removeCustomBucketSecret(t, body)
@@ -64,6 +65,7 @@ func TestResourceSource(t *testing.T) {
 			patched = inject(t, patched, "token", "generated_by_logtail")
 			patched = inject(t, patched, "ingesting_host", "in.logs.betterstack.com")
 			patched = inject(t, patched, "table_name", "test_source")
+			patched = inject(t, patched, "team_id", 123456)
 
 			// Handle custom_bucket - remove secret_access_key from response as API doesn't return it
 			patched = removeCustomBucketSecret(t, patched)

--- a/internal/provider/type_string_or_int.go
+++ b/internal/provider/type_string_or_int.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// StringOrInt handles JSON fields that can be either a string or an integer.
+// It unmarshals both "t1234" (string) and 123456 (number) into a string value,
+// and marshals back to the appropriate JSON type based on the value.
+//
+// This is used for fields like team_id in the Better Stack API which can return:
+// - A number: 12345
+// - A string: "t1234"
+//
+// When marshaling:
+// - Pure numeric strings like "1234" are marshaled as JSON numbers: 1234
+// - Non-numeric strings like "t1234" are marshaled as JSON strings: "t1234"
+//
+// Example usage in resource_source.go:
+//
+//	type source struct {
+//	    TeamId *StringOrInt `json:"team_id,omitempty"`
+//	}
+type StringOrInt string
+
+// MarshalJSON implements json.Marshaler interface.
+// Used when sending data to the Better Stack API:
+// - If the value is a pure number (e.g., "1234"), marshals as JSON number: 1234
+// - If the value contains non-numeric characters (e.g., "t1234"), marshals as JSON string: "t1234"
+func (s StringOrInt) MarshalJSON() ([]byte, error) {
+	str := string(s)
+	// Try to parse as integer - if successful, marshal as number
+	if n, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return json.Marshal(n)
+	}
+	// Otherwise marshal as string
+	return json.Marshal(str)
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+// Used when receiving data from the Better Stack API:
+// - When the JSON value is a string (e.g., "t1234"), stores it as-is
+// - When the JSON value is a number (e.g., 123456), converts it to a string
+func (s *StringOrInt) UnmarshalJSON(data []byte) error {
+	// Try string first (handles "t1234", "b654654")
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		*s = StringOrInt(str)
+		return nil
+	}
+	// Try number (handles 6547, 123456)
+	var n json.Number
+	if err := json.Unmarshal(data, &n); err == nil {
+		*s = StringOrInt(n.String())
+		return nil
+	}
+	return fmt.Errorf("cannot unmarshal %s into StringOrInt", data)
+}
+
+// String returns the underlying string value.
+func (s StringOrInt) String() string {
+	return string(s)
+}
+
+// StringOrIntFromResourceData creates a StringOrInt from a Terraform resource field.
+// Used in sourceCreate and sourceUpdate to handle fields that can be string or int.
+//
+// Parameters:
+//   - d: The Terraform resource data
+//   - key: The field name (e.g., "team_id")
+//
+// Example:
+//
+//	in.TeamId = StringOrIntFromResourceData(d, "team_id")
+func StringOrIntFromResourceData(d *schema.ResourceData, key string) *StringOrInt {
+	if v, ok := d.GetOk(key); ok {
+		if v == nil {
+			return nil
+		}
+		str := v.(string)
+		result := StringOrInt(str)
+		return &result
+	}
+	return nil
+}
+
+// SetStringOrIntResourceData sets a Terraform resource field from a StringOrInt.
+// Used in sourceCopyAttrs to handle fields that can be string or int.
+//
+// Parameters:
+//   - d: The Terraform resource data
+//   - key: The field name (e.g., "team_id")
+//   - value: The StringOrInt value from the API
+//
+// Example:
+//
+//	SetStringOrIntResourceData(d, "team_id", in.TeamId)
+func SetStringOrIntResourceData(d *schema.ResourceData, key string, value *StringOrInt) error {
+	if value == nil {
+		return d.Set(key, nil)
+	}
+	return d.Set(key, string(*value))
+}


### PR DESCRIPTION
In combination with an output parameter (or local provider) it can be used to create proper queries for clickhouse