### PR TITLE
T-4418 add skip_ssl_verify to prometheus scrape sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.9.2
+VERSION := 0.9.3
 .PHONY: test build
 
 help:

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -90,6 +90,7 @@ This Data Source allows you to look up existing Sources using their table name. 
 - `scrape_request_basic_auth_user` (String) Basic auth username for scraping.
 - `scrape_request_headers` (List of Map of String) An array of request headers, each containing `name` and `value` fields.
 - `scrape_urls` (List of String) For scrape platform types, the set of urls to scrape.
+- `skip_ssl_verify` (Boolean) Should the scraper skip SSL certificate verification? Enable for endpoints with self-signed or invalid certificates.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
 - `team_id` (String) The team ID for this resource. Can be used with table_name in [Query API](https://betterstack.com/docs/logs/query-api/connect-remotely/).
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -86,6 +86,7 @@ This resource allows you to create, modify, and delete your Sources. For more in
 - `scrape_request_basic_auth_user` (String) Basic auth username for scraping.
 - `scrape_request_headers` (List of Map of String) An array of request headers, each containing `name` and `value` fields.
 - `scrape_urls` (List of String) For scrape platform types, the set of urls to scrape.
+- `skip_ssl_verify` (Boolean) Should the scraper skip SSL certificate verification? Enable for endpoints with self-signed or invalid certificates.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `vrl_transformation` (String) VRL transformation that runs on Better Stack's servers during ingestion. Note: data has already left your infrastructure at this point. For transformations that must run before data leaves your network (e.g. PII redaction), use `logtail_collector` with `configuration.vrl_transformation` instead. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).

--- a/examples/scrape/main.tf
+++ b/examples/scrape/main.tf
@@ -15,4 +15,5 @@ resource "logtail_source" "this" {
   ]
   scrape_request_basic_auth_user     = "foo"
   scrape_request_basic_auth_password = "bar"
+  skip_ssl_verify                    = true
 }

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -207,6 +207,12 @@ var sourceSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Sensitive:   true,
 	},
+	"skip_ssl_verify": {
+		Description: "Should the scraper skip SSL certificate verification? Enable for endpoints with self-signed or invalid certificates.",
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Computed:    true,
+	},
 	"data_region": {
 		Description: "Data region or private cluster name to create the source in. Permitted values for most plans are: `us_east`, `germany`, `singapore`.",
 		Type:        schema.TypeString,
@@ -333,6 +339,7 @@ type source struct {
 	ScrapeRequestHeaders           *[]map[string]interface{} `json:"scrape_request_headers,omitempty"`
 	ScrapeRequestBasicAuthUser     *string                   `json:"scrape_request_basic_auth_user,omitempty"`
 	ScrapeRequestBasicAuthPassword *string                   `json:"scrape_request_basic_auth_password,omitempty"`
+	SkipSSLVerify                  *bool                     `json:"skip_ssl_verify,omitempty"`
 	DataRegion                     *string                   `json:"data_region,omitempty"`
 	SourceGroupID                  *int                      `json:"source_group_id,omitempty"`
 	CustomBucket                   *sourceCustomBucket       `json:"custom_bucket,omitempty"`
@@ -373,6 +380,7 @@ func sourceRef(in *source) []struct {
 		{k: "scrape_request_headers", v: &in.ScrapeRequestHeaders},
 		{k: "scrape_request_basic_auth_user", v: &in.ScrapeRequestBasicAuthUser},
 		{k: "scrape_request_basic_auth_password", v: &in.ScrapeRequestBasicAuthPassword},
+		{k: "skip_ssl_verify", v: &in.SkipSSLVerify},
 		{k: "data_region", v: &in.DataRegion},
 		{k: "source_group_id", v: &in.SourceGroupID},
 		{k: "vrl_transformation", v: &in.VrlTransformation},

--- a/internal/provider/resource_source_test.go
+++ b/internal/provider/resource_source_test.go
@@ -240,6 +240,7 @@ func TestResourceSource(t *testing.T) {
 					platform         = "%s"
 					scrape_urls      = ["http://localhost:9100/metrics", "http://localhost:9101/metrics"]
 					scrape_frequency_secs = 60
+					skip_ssl_verify       = true
 				}
 				`, name, platform_scrape),
 				Check: resource.ComposeTestCheckFunc(
@@ -250,6 +251,7 @@ func TestResourceSource(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_source.this", "token", "generated_by_logtail"),
 					resource.TestCheckResourceAttr("logtail_source.this", "scrape_urls.#", "2"),
 					resource.TestCheckResourceAttr("logtail_source.this", "scrape_frequency_secs", "60"),
+					resource.TestCheckResourceAttr("logtail_source.this", "skip_ssl_verify", "true"),
 				),
 			},
 			// Step 2 - update.
@@ -276,6 +278,7 @@ func TestResourceSource(t *testing.T) {
 							value = "Bearer foo"
 						}
 					]
+					skip_ssl_verify = false
 				}
 				`, name, platform_scrape),
 				Check: resource.ComposeTestCheckFunc(
@@ -293,6 +296,7 @@ func TestResourceSource(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_source.this", "scrape_request_headers.0.value", "Bearer foo"),
 					resource.TestCheckResourceAttr("logtail_source.this", "scrape_request_basic_auth_user", "user1"),
 					resource.TestCheckResourceAttr("logtail_source.this", "scrape_request_basic_auth_password", "password1"),
+					resource.TestCheckResourceAttr("logtail_source.this", "skip_ssl_verify", "false"),
 				),
 			},
 			// Step 3 - make no changes, check plan is empty (omitted attributes are not controlled)


### PR DESCRIPTION
Adds support for the newly added `skip_ssl_verify` option for sources, which permits Prometheus scraping even for endpoints with invalid SSL certificates.