### PR TITLE
Add team_id to errors_application resource and data source

### DIFF
--- a/docs/data-sources/errors_application.md
+++ b/docs/data-sources/errors_application.md
@@ -128,6 +128,7 @@ This Data Source allows you to look up existing Errors applications using their 
     - `wpf_errors`
     - `wsgi_errors`
 - `table_name` (String) The table name generated for this application.
+- `team_id` (String) The team ID for this resource.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `token` (String) The token of this application. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this application was updated.

--- a/docs/resources/errors_application.md
+++ b/docs/resources/errors_application.md
@@ -132,6 +132,7 @@ This resource allows you to create, modify, and delete your Errors applications.
 - `id` (String) The ID of this application.
 - `ingesting_host` (String) The host where the errors should be sent. See documentation for your specific platform for details.
 - `table_name` (String) The table name generated for this application.
+- `team_id` (String) The team ID for this resource.
 - `token` (String) The token of this application. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this application was updated.
 

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -124,6 +124,12 @@ var errorsApplicationSchema = map[string]*schema.Schema{
 			return d.Id() != ""
 		},
 	},
+	"team_id": {
+		Description: "The team ID for this resource.",
+		Type:        schema.TypeString,
+		Optional:    false,
+		Computed:    true,
+	},
 	"id": {
 		Description: "The ID of this application.",
 		Type:        schema.TypeString,
@@ -294,6 +300,7 @@ func newErrorsApplicationResource() *schema.Resource {
 type errorsApplication struct {
 	Name                  *string             `json:"name,omitempty"`
 	Token                 *string             `json:"token,omitempty"`
+	TeamId                *StringOrInt        `json:"team_id,omitempty"`
 	TableName             *string             `json:"table_name,omitempty"`
 	Platform              *string             `json:"platform,omitempty"`
 	IngestingHost         *string             `json:"ingesting_host,omitempty"`
@@ -326,6 +333,7 @@ func errorsApplicationRef(in *errorsApplication) []struct {
 	}{
 		{k: "name", v: &in.Name},
 		{k: "token", v: &in.Token},
+		{k: "team_id", v: &in.TeamId},
 		{k: "table_name", v: &in.TableName},
 		{k: "platform", v: &in.Platform},
 		{k: "ingesting_host", v: &in.IngestingHost},
@@ -343,7 +351,9 @@ func errorsApplicationRef(in *errorsApplication) []struct {
 func errorsApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in errorsApplication
 	for _, e := range errorsApplicationRef(&in) {
-		if e.k == "application_group_id" {
+		if e.k == "team_id" {
+			in.TeamId = StringOrIntFromResourceData(d, e.k)
+		} else if e.k == "application_group_id" {
 			// Use intFromResourceData to properly distinguish null vs 0
 			in.ApplicationGroupID = intFromResourceData(d, e.k)
 		} else {
@@ -401,6 +411,10 @@ func errorsApplicationCopyAttrs(d *schema.ResourceData, in *errorsApplication) d
 		} else if e.k == "platform" && d.Get("platform").(string) != "" {
 			// Don't update platform from API if it's already set - platform can't change and API doesn't return it
 			continue
+		} else if e.k == "team_id" {
+			if err := SetStringOrIntResourceData(d, "team_id", in.TeamId); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		} else if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}
@@ -442,7 +456,9 @@ func errorsApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	var in errorsApplication
 	for _, e := range errorsApplicationRef(&in) {
 		if d.HasChange(e.k) {
-			if e.k == "application_group_id" {
+			if e.k == "team_id" {
+				in.TeamId = StringOrIntFromResourceData(d, e.k)
+			} else if e.k == "application_group_id" {
 				// Use intFromResourceData to properly distinguish null vs 0
 				in.ApplicationGroupID = intFromResourceData(d, e.k)
 			} else {

--- a/internal/provider/resource_errors_application_test.go
+++ b/internal/provider/resource_errors_application_test.go
@@ -35,6 +35,7 @@ func TestResourceErrorsApplication(t *testing.T) {
 			body = inject(t, body, "token", "generated_by_logtail")
 			body = inject(t, body, "ingesting_host", "s1234.us-east-9.betterstackdata.com")
 			body = inject(t, body, "table_name", "test_errors_application")
+			body = inject(t, body, "team_id", 123456)
 
 			// Handle custom_bucket - remove secret_access_key from response as API doesn't return it
 			body = removeCustomBucketSecret(t, body)
@@ -63,6 +64,7 @@ func TestResourceErrorsApplication(t *testing.T) {
 			patched = inject(t, patched, "token", "generated_by_logtail")
 			patched = inject(t, patched, "ingesting_host", "s1234.us-east-9.betterstackdata.com")
 			patched = inject(t, patched, "table_name", "test_errors_application")
+			patched = inject(t, patched, "team_id", 123456)
 
 			// Handle custom_bucket - remove secret_access_key from response as API doesn't return it
 			patched = removeCustomBucketSecret(t, patched)
@@ -109,6 +111,7 @@ func TestResourceErrorsApplication(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_errors_application.this", "platform", platform),
 					resource.TestCheckResourceAttr("logtail_errors_application.this", "token", "generated_by_logtail"),
 					resource.TestCheckResourceAttr("logtail_errors_application.this", "ingesting_host", "s1234.us-east-9.betterstackdata.com"),
+					resource.TestCheckResourceAttr("logtail_errors_application.this", "team_id", "123456"),
 					resource.TestCheckResourceAttr("logtail_errors_application.this", "data_region", "us-east-9"),
 					resource.TestCheckResourceAttr("logtail_errors_application.this", "errors_retention", "90"),
 				),


### PR DESCRIPTION
## Summary
- Expose `team_id` from the Better Stack Errors API as a computed read-only attribute on `logtail_errors_application` resource and data source
- Uses the existing `StringOrInt` type, following the same pattern as the `logtail_source` resource
- Updates documentation for both resource and data source

## Test plan
- [x] All existing `TestResourceErrorsApplication*` tests pass
- [x] New `team_id` assertion added to `TestResourceErrorsApplication` (injected as integer `123456`, verified as string `"123456"`)