### PR TITLE
T-17166 Remove unsupported proxy options in Collector after API simplification

### DIFF
--- a/docs/data-sources/collector.md
+++ b/docs/data-sources/collector.md
@@ -42,8 +42,7 @@ data "logtail_collector" "production" {
 - `metrics_retention` (Number) Data retention for metrics in days. Allowed values: 7, 30, 60, 90, 180, 365, 730, 1095, 1460, 1825. There might be additional charges for longer retention.
 - `note` (String) A description or note about this collector.
 - `pinged_at` (String) The time when this collector last received data.
-- `platform` (String) The platform of this collector. This value can be set only when creating a new collector and cannot be changed later. Valid values are: `docker`, `swarm`, `kubernetes`, `proxy`.
-- `proxy_config` (List of Object) Proxy settings including buffering proxy, SSL/TLS, and HTTP Basic Authentication. Only applicable to `proxy` platform collectors. (see [below for nested schema](#nestedatt--proxy_config))
+- `platform` (String) The platform of this collector. This value can be set only when creating a new collector and cannot be changed later. Valid values are: `docker`, `swarm`, `kubernetes`.
 - `secret` (String, Sensitive) The secret token used to authenticate collector hosts.
 - `source_group_id` (Number) The ID of the source group (folder) this collector belongs to. Set to `0` to remove from a group.
 - `source_id` (Number) The ID of the underlying source. Use this with `logtail_metric` to define metrics on this collector's data.
@@ -133,17 +132,3 @@ Read-Only:
 - `ssl_mode` (String)
 - `tls` (String)
 - `username` (String)
-
-
-<a id="nestedatt--proxy_config"></a>
-### Nested Schema for `proxy_config`
-
-Read-Only:
-
-- `buffering_proxy_listen_on` (String)
-- `enable_buffering_proxy` (Boolean)
-- `enable_http_basic_auth` (Boolean)
-- `enable_ssl_certificate` (Boolean)
-- `http_basic_auth_password` (String)
-- `http_basic_auth_username` (String)
-- `ssl_certificate_host` (String)

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -55,7 +55,7 @@ resource "logtail_collector" "production" {
 ### Required
 
 - `name` (String) The name of this collector.
-- `platform` (String) The platform of this collector. This value can be set only when creating a new collector and cannot be changed later. Valid values are: `docker`, `swarm`, `kubernetes`, `proxy`.
+- `platform` (String) The platform of this collector. This value can be set only when creating a new collector and cannot be changed later. Valid values are: `docker`, `swarm`, `kubernetes`.
 
 ### Optional
 
@@ -68,7 +68,6 @@ resource "logtail_collector" "production" {
 - `logs_retention` (Number) Data retention for logs in days. Allowed values: 7, 30, 60, 90, 180, 365, 730, 1095, 1460, 1825. There might be additional charges for longer retention.
 - `metrics_retention` (Number) Data retention for metrics in days. Allowed values: 7, 30, 60, 90, 180, 365, 730, 1095, 1460, 1825. There might be additional charges for longer retention.
 - `note` (String) A description or note about this collector.
-- `proxy_config` (Block List, Max: 1) Proxy settings including buffering proxy, SSL/TLS, and HTTP Basic Authentication. Only applicable to `proxy` platform collectors. (see [below for nested schema](#nestedblock--proxy_config))
 - `source_group_id` (Number) The ID of the source group (folder) this collector belongs to. Set to `0` to remove from a group.
 - `source_vrl_transformation` (String) Server-side VRL transformation that runs during ingestion on Better Stack. Use this for enrichment, routing, or light normalization that doesn't involve sensitive data. For PII redaction and sensitive data filtering, prefer `configuration.vrl_transformation` which runs on the collector host and ensures raw data never leaves your network. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
@@ -182,17 +181,3 @@ Optional:
 Read-Only:
 
 - `id` (Number) The ID of this database connection (assigned by the API).
-
-
-<a id="nestedblock--proxy_config"></a>
-### Nested Schema for `proxy_config`
-
-Optional:
-
-- `buffering_proxy_listen_on` (String) Address and port for the buffering proxy to listen on.
-- `enable_buffering_proxy` (Boolean) Enable the HTTP buffering proxy for the collector.
-- `enable_http_basic_auth` (Boolean) Enable HTTP Basic Authentication for the collector proxy.
-- `enable_ssl_certificate` (Boolean) Enable custom SSL/TLS certificate for the collector.
-- `http_basic_auth_password` (String, Sensitive) Password for HTTP Basic Authentication. This value is write-only and never returned by the API.
-- `http_basic_auth_username` (String) Username for HTTP Basic Authentication.
-- `ssl_certificate_host` (String) Hostname for the SSL certificate.

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -138,58 +138,6 @@ resource "logtail_collector" "with_databases" {
 }
 
 # ---------------------------------------------------------------------------
-# Proxy collector with auth, SSL, and custom Vector YAML
-# ---------------------------------------------------------------------------
-resource "logtail_collector" "proxy_with_auth" {
-  name     = "E2E Proxy ${random_pet.unique.id}"
-  platform = "proxy"
-  note     = "Proxy collector with authentication and custom SSL"
-
-  proxy_config {
-    enable_http_basic_auth    = true
-    http_basic_auth_username  = "api_user"
-    http_basic_auth_password  = var.proxy_password
-    enable_ssl_certificate    = true
-    ssl_certificate_host      = "logs.example.com"
-    enable_buffering_proxy    = true
-    buffering_proxy_listen_on = "0.0.0.0:8080"
-  }
-
-  # Looking for sinks to send data to Better Stack?
-  # The sink `better_stack_http_logs_sink` in generated.vector.yaml will automatically pick up any source or transform with a name starting with `better_stack_logs_`.
-  # Sinks `better_stack_http_traces_sink` and `better_stack_http_metrics_sink` will pick up any source or transform with a name starting with `better_stack_traces_` and `better_stack_metrics_` respectively.
-  user_vector_config = <<-EOT
-    sources:
-      better_stack_logs_my_custom_input:
-        type: file
-        include:
-          - "/var/log/app/*.log"
-
-      better_stack_traces_sample_input:
-        type: file
-        include:
-          - /dev/null
-
-      better_stack_metrics_sample_input:
-        type: static_metrics
-  EOT
-
-  configuration {
-    logs_sample_rate   = 100
-    traces_sample_rate = 50
-
-    disk_batch_size_mb   = 512
-    memory_batch_size_mb = 20
-
-    # VRL transformation to normalize log levels
-    vrl_transformation = <<-EOT
-      .level = downcase!(.level)
-      .processed_at = now()
-    EOT
-  }
-}
-
-# ---------------------------------------------------------------------------
 # Data source to look up a collector created above
 # ---------------------------------------------------------------------------
 data "logtail_collector" "existing" {

--- a/examples/collector/variables.tf
+++ b/examples/collector/variables.tf
@@ -14,10 +14,3 @@ variable "db_password" {
   # Default for e2e testing — the database host is not real, so the password is not used.
   default = "e2e_test_password"
 }
-
-variable "proxy_password" {
-  description = "Password for HTTP Basic Auth on proxy collector"
-  type        = string
-  # Default for e2e testing — the proxy collector is destroyed after each run.
-  default = "e2e_test_proxy_password"
-}

--- a/internal/provider/resource_collector.go
+++ b/internal/provider/resource_collector.go
@@ -51,7 +51,6 @@ var collectorPlatformTypes = []string{
 	"docker",
 	"swarm",
 	"kubernetes",
-	"proxy",
 }
 
 var collectorSchema = map[string]*schema.Schema{
@@ -82,7 +81,7 @@ var collectorSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"platform": {
-		Description:  "The platform of this collector. This value can be set only when creating a new collector and cannot be changed later. Valid values are: `docker`, `swarm`, `kubernetes`, `proxy`.",
+		Description:  "The platform of this collector. This value can be set only when creating a new collector and cannot be changed later. Valid values are: `docker`, `swarm`, `kubernetes`.",
 		Type:         schema.TypeString,
 		Required:     true,
 		ForceNew:     true,
@@ -313,55 +312,6 @@ var collectorSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"proxy_config": {
-		Description: "Proxy settings including buffering proxy, SSL/TLS, and HTTP Basic Authentication. Only applicable to `proxy` platform collectors.",
-		Type:        schema.TypeList,
-		Optional:    true,
-		MaxItems:    1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"enable_buffering_proxy": {
-					Description: "Enable the HTTP buffering proxy for the collector.",
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Default:     false,
-				},
-				"buffering_proxy_listen_on": {
-					Description: "Address and port for the buffering proxy to listen on.",
-					Type:        schema.TypeString,
-					Optional:    true,
-				},
-				"enable_ssl_certificate": {
-					Description: "Enable custom SSL/TLS certificate for the collector.",
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Default:     false,
-				},
-				"ssl_certificate_host": {
-					Description: "Hostname for the SSL certificate.",
-					Type:        schema.TypeString,
-					Optional:    true,
-				},
-				"enable_http_basic_auth": {
-					Description: "Enable HTTP Basic Authentication for the collector proxy.",
-					Type:        schema.TypeBool,
-					Optional:    true,
-					Default:     false,
-				},
-				"http_basic_auth_username": {
-					Description: "Username for HTTP Basic Authentication.",
-					Type:        schema.TypeString,
-					Optional:    true,
-				},
-				"http_basic_auth_password": {
-					Description: "Password for HTTP Basic Authentication. This value is write-only and never returned by the API.",
-					Type:        schema.TypeString,
-					Optional:    true,
-					Sensitive:   true,
-				},
-			},
-		},
-	},
 	"custom_bucket": {
 		Description: "Optional custom bucket configuration for the collector. Once set, it cannot be removed.",
 		Type:        schema.TypeList,
@@ -430,16 +380,6 @@ type collectorConfiguration struct {
 	NamespacesOptions map[string]collectorEntityOption `json:"namespaces_options,omitempty"`
 }
 
-type collectorProxyConfig struct {
-	EnableBufferingProxy   *bool   `json:"enable_buffering_proxy,omitempty"`
-	BufferingProxyListenOn *string `json:"buffering_proxy_listen_on,omitempty"`
-	EnableSSLCertificate   *bool   `json:"enable_ssl_certificate,omitempty"`
-	SSLCertificateHost     *string `json:"ssl_certificate_host,omitempty"`
-	EnableHTTPBasicAuth    *bool   `json:"enable_http_basic_auth,omitempty"`
-	HTTPBasicAuthUsername  *string `json:"http_basic_auth_username,omitempty"`
-	HTTPBasicAuthPassword  *string `json:"http_basic_auth_password,omitempty"`
-}
-
 type collectorCustomBucket struct {
 	Name                   *string `json:"name,omitempty"`
 	Endpoint               *string `json:"endpoint,omitempty"`
@@ -484,7 +424,6 @@ type collector struct {
 	UserVectorConfig        *string                 `json:"user_vector_config,omitempty"`
 	SourceVrlTransformation *string                 `json:"source_vrl_transformation,omitempty"`
 	Configuration           *collectorConfiguration `json:"configuration,omitempty"`
-	ProxyConfig             *collectorProxyConfig   `json:"proxy_config,omitempty"`
 	CustomBucket            *collectorCustomBucket  `json:"custom_bucket,omitempty"`
 	Databases               *[]collectorDatabase    `json:"databases,omitempty"`
 }
@@ -784,43 +723,6 @@ func loadCollectorConfiguration(d *schema.ResourceData) *collectorConfiguration 
 	return cfg
 }
 
-// loadCollectorProxyConfig reads the proxy_config block into the API struct.
-func loadCollectorProxyConfig(d *schema.ResourceData, in *collector) {
-	proxyData, ok := d.GetOk("proxy_config")
-	if !ok {
-		return
-	}
-	proxyList := proxyData.([]interface{})
-	if len(proxyList) == 0 {
-		return
-	}
-	pm := proxyList[0].(map[string]interface{})
-
-	pc := &collectorProxyConfig{}
-	if v, ok := pm["enable_buffering_proxy"].(bool); ok {
-		pc.EnableBufferingProxy = boolPtr(v)
-	}
-	if v, ok := pm["buffering_proxy_listen_on"].(string); ok && v != "" {
-		pc.BufferingProxyListenOn = stringPtr(v)
-	}
-	if v, ok := pm["enable_ssl_certificate"].(bool); ok {
-		pc.EnableSSLCertificate = boolPtr(v)
-	}
-	if v, ok := pm["ssl_certificate_host"].(string); ok && v != "" {
-		pc.SSLCertificateHost = stringPtr(v)
-	}
-	if v, ok := pm["enable_http_basic_auth"].(bool); ok {
-		pc.EnableHTTPBasicAuth = boolPtr(v)
-	}
-	if v, ok := pm["http_basic_auth_username"].(string); ok && v != "" {
-		pc.HTTPBasicAuthUsername = stringPtr(v)
-	}
-	if v, ok := pm["http_basic_auth_password"].(string); ok && v != "" {
-		pc.HTTPBasicAuthPassword = stringPtr(v)
-	}
-	in.ProxyConfig = pc
-}
-
 func collectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in collector
 	for _, e := range collectorRef(&in) {
@@ -837,9 +739,6 @@ func collectorCreate(ctx context.Context, d *schema.ResourceData, meta interface
 
 	// Load configuration
 	in.Configuration = loadCollectorConfiguration(d)
-
-	// Load proxy config (buffering proxy, SSL, HTTP Basic Auth)
-	loadCollectorProxyConfig(d, &in)
 
 	// Load custom_bucket
 	if customBucketData, ok := d.GetOk("custom_bucket"); ok {
@@ -939,11 +838,6 @@ func collectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface
 			}
 			mergeEntityOptions(in.Configuration, serverCfg)
 		}
-	}
-
-	// Load proxy config if changed (buffering proxy, SSL, HTTP Basic Auth)
-	if d.HasChange("proxy_config") {
-		loadCollectorProxyConfig(d, &in)
 	}
 
 	// Load custom_bucket if changed
@@ -1131,50 +1025,6 @@ func collectorCopyAttrs(d *schema.ResourceData, in *collector) diag.Diagnostics 
 		}
 	}
 
-	// Copy proxy_config from the API response (only returned for proxy-platform collectors).
-	if in.ProxyConfig != nil {
-		proxyData := make(map[string]interface{})
-		if in.ProxyConfig.EnableBufferingProxy != nil {
-			proxyData["enable_buffering_proxy"] = *in.ProxyConfig.EnableBufferingProxy
-		}
-		if in.ProxyConfig.BufferingProxyListenOn != nil {
-			proxyData["buffering_proxy_listen_on"] = *in.ProxyConfig.BufferingProxyListenOn
-		}
-		if in.ProxyConfig.EnableSSLCertificate != nil {
-			proxyData["enable_ssl_certificate"] = *in.ProxyConfig.EnableSSLCertificate
-		}
-		if in.ProxyConfig.SSLCertificateHost != nil {
-			proxyData["ssl_certificate_host"] = *in.ProxyConfig.SSLCertificateHost
-		}
-		if in.ProxyConfig.EnableHTTPBasicAuth != nil {
-			proxyData["enable_http_basic_auth"] = *in.ProxyConfig.EnableHTTPBasicAuth
-		}
-		if in.ProxyConfig.HTTPBasicAuthUsername != nil {
-			proxyData["http_basic_auth_username"] = *in.ProxyConfig.HTTPBasicAuthUsername
-		}
-
-		// Preserve http_basic_auth_password from existing state (API never returns it)
-		if existingProxy, ok := d.GetOk("proxy_config"); ok {
-			existingList := existingProxy.([]interface{})
-			if len(existingList) > 0 {
-				existingMap := existingList[0].(map[string]interface{})
-				if password, ok := existingMap["http_basic_auth_password"]; ok {
-					proxyData["http_basic_auth_password"] = password
-				}
-			}
-		}
-
-		if err := d.Set("proxy_config", []interface{}{proxyData}); err != nil {
-			derr = append(derr, diag.FromErr(err)[0])
-		}
-	} else if _, userDeclared := d.GetOk("proxy_config"); userDeclared {
-		// API returned nil proxy_config (non-proxy platform) but user declared it —
-		// clear it from state to avoid drift.
-		if err := d.Set("proxy_config", nil); err != nil {
-			derr = append(derr, diag.FromErr(err)[0])
-		}
-	}
-
 	// Copy custom_bucket (preserve secret_access_key from state)
 	if in.CustomBucket != nil {
 		customBucketData := make(map[string]interface{})
@@ -1268,17 +1118,6 @@ func collectorCopyAttrs(d *schema.ResourceData, in *collector) diag.Diagnostics 
 }
 
 func validateCollector(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
-	// Reject proxy_config for non-proxy platforms at plan time
-	if proxyConfig, ok := diff.GetOk("proxy_config"); ok {
-		proxyList := proxyConfig.([]interface{})
-		if len(proxyList) > 0 {
-			platform := diff.Get("platform").(string)
-			if platform != "proxy" {
-				return fmt.Errorf("proxy_config is only applicable to proxy platform collectors, but platform is %q", platform)
-			}
-		}
-	}
-
 	if diff.Id() != "" && diff.HasChange("data_region") {
 		return fmt.Errorf("data_region cannot be changed after collector is created")
 	}

--- a/internal/provider/resource_collector_test.go
+++ b/internal/provider/resource_collector_test.go
@@ -47,7 +47,6 @@ func TestResourceCollector(t *testing.T) {
 			body = removeCustomBucketSecret(t, body)
 
 			// Handle HTTP Basic Auth - move enable flag to configuration and remove password
-			body = processProxyConfig(t, body)
 
 			// Extract databases and store separately, replace with databases_count in main response
 			body, databases := extractDatabasesFromResponse(t, body)
@@ -90,7 +89,6 @@ func TestResourceCollector(t *testing.T) {
 			patched = removeCustomBucketSecret(t, patched)
 
 			// Handle HTTP Basic Auth - move enable flag to configuration and remove password
-			patched = processProxyConfig(t, patched)
 
 			// Handle databases update - process _destroy, then extract and store separately
 			patched = processDatabasesUpdate(t, patched)
@@ -420,36 +418,6 @@ func TestResourceCollector(t *testing.T) {
 				`, name, platform),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`data_region cannot be changed after collector is created`),
-			},
-		},
-	})
-
-	// Test proxy_config rejected for non-proxy platforms
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"logtail": func() (*schema.Provider, error) {
-				return New(WithURL(server.URL)), nil
-			},
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_buffering_proxy = true
-					}
-				}
-				`, name, platform),
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`proxy_config is only applicable to proxy platform collectors`),
 			},
 		},
 	})
@@ -982,28 +950,6 @@ func processDatabasesUpdate(t *testing.T, body json.RawMessage) json.RawMessage 
 	return body
 }
 
-// processProxyConfig handles proxy_config fields.
-// The API nests all proxy settings under proxy_config in the response.
-// http_basic_auth_password is removed (write-only field, never returned by the API).
-func processProxyConfig(t *testing.T, body json.RawMessage) json.RawMessage {
-	response := make(map[string]interface{})
-	if err := json.Unmarshal(body, &response); err != nil {
-		t.Fatal(err)
-	}
-
-	// If proxy_config exists, remove password from it
-	if proxyConfig, ok := response["proxy_config"].(map[string]interface{}); ok {
-		delete(proxyConfig, "http_basic_auth_password")
-	}
-
-	body, err := json.Marshal(response)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return body
-}
-
 func TestResourceCollectorNewFeatures(t *testing.T) {
 	var collectorData atomic.Value
 	var databasesData atomic.Value
@@ -1032,7 +978,7 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 			body = inject(t, body, "hosts_count", 0)
 			body = inject(t, body, "hosts_up_count", 0)
 			body = removeCustomBucketSecret(t, body)
-			body = processProxyConfig(t, body)
+
 			body, databases := extractDatabasesFromResponse(t, body)
 			databasesData.Store(databases)
 			collectorData.Store(body)
@@ -1067,7 +1013,7 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 			patched = inject(t, patched, "team_id", 123456)
 			patched = inject(t, patched, "source_id", 42)
 			patched = removeCustomBucketSecret(t, patched)
-			patched = processProxyConfig(t, patched)
+
 			patched = processDatabasesUpdate(t, patched)
 			patched, databases := extractDatabasesFromResponse(t, patched)
 			databasesData.Store(databases)
@@ -1086,7 +1032,7 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 	defer server.Close()
 
 	var name = "Test Collector"
-	var platform = "proxy"
+	var platform = "docker"
 
 	// Test VRL transformation
 	resource.Test(t, resource.TestCase{
@@ -1142,145 +1088,6 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 		},
 	})
 
-	// Test SSL/TLS certificate settings via proxy_config
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"logtail": func() (*schema.Provider, error) {
-				return New(WithURL(server.URL)), nil
-			},
-		},
-		Steps: []resource.TestStep{
-			// Step 1 - create with SSL settings
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_ssl_certificate = true
-						ssl_certificate_host   = "logs.example.com"
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("logtail_collector.this", "id"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.#", "1"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_ssl_certificate", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.ssl_certificate_host", "logs.example.com"),
-				),
-			},
-			// Step 2 - update SSL settings
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_ssl_certificate = true
-						ssl_certificate_host   = "logs2.example.com"
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.ssl_certificate_host", "logs2.example.com"),
-				),
-			},
-		},
-	})
-
-	// Test HTTP Basic Auth via proxy_config
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"logtail": func() (*schema.Provider, error) {
-				return New(WithURL(server.URL)), nil
-			},
-		},
-		Steps: []resource.TestStep{
-			// Step 1 - create with proxy_config
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_http_basic_auth   = true
-						http_basic_auth_username = "api_user"
-						http_basic_auth_password = "secret_password"
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("logtail_collector.this", "id"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.#", "1"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_http_basic_auth", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.http_basic_auth_username", "api_user"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.http_basic_auth_password", "secret_password"),
-				),
-			},
-			// Step 2 - update username (password preserved)
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_http_basic_auth   = true
-						http_basic_auth_username = "new_user"
-						http_basic_auth_password = "secret_password"
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_http_basic_auth", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.http_basic_auth_username", "new_user"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.http_basic_auth_password", "secret_password"),
-				),
-			},
-			// Step 3 - disable HTTP Basic Auth
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_http_basic_auth = false
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_http_basic_auth", "false"),
-				),
-			},
-		},
-	})
-
 	// Test user_vector_config
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -1325,75 +1132,6 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 				`, name, platform),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("logtail_collector.this", "user_vector_config", "sources:\n  updated_input:\n    type: file\n"),
-				),
-			},
-		},
-	})
-
-	// Test batching (in configuration) and buffering proxy (in proxy_config)
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"logtail": func() (*schema.Provider, error) {
-				return New(WithURL(server.URL)), nil
-			},
-		},
-		Steps: []resource.TestStep{
-			// Step 1 - create with batching config and buffering proxy
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					configuration {
-						disk_batch_size_mb   = 512
-						memory_batch_size_mb = 20
-					}
-
-					proxy_config {
-						enable_buffering_proxy    = true
-						buffering_proxy_listen_on = "0.0.0.0:8080"
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("logtail_collector.this", "id"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.disk_batch_size_mb", "512"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.memory_batch_size_mb", "20"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_buffering_proxy", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.buffering_proxy_listen_on", "0.0.0.0:8080"),
-				),
-			},
-			// Step 2 - update batching config and disable buffering proxy
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					configuration {
-						disk_batch_size_mb   = 1024
-						memory_batch_size_mb = 30
-					}
-
-					proxy_config {
-						enable_buffering_proxy = false
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.disk_batch_size_mb", "1024"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.memory_batch_size_mb", "30"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_buffering_proxy", "false"),
 				),
 			},
 		},
@@ -1529,61 +1267,6 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 						"name": "my-service", "log_sampling": "100", "ingest_traces": "true",
 					}),
 					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.namespace_option.#", "2"),
-				),
-			},
-		},
-	})
-
-	// Test combined features (proxy_config has SSL + basic auth + buffering, configuration has sampling + VRL)
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"logtail": func() (*schema.Provider, error) {
-				return New(WithURL(server.URL)), nil
-			},
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-				provider "logtail" {
-					api_token = "foo"
-				}
-
-				resource "logtail_collector" "this" {
-					name     = "%s"
-					platform = "%s"
-
-					proxy_config {
-						enable_http_basic_auth    = true
-						http_basic_auth_username  = "proxy_user"
-						http_basic_auth_password  = "proxy_pass"
-						enable_ssl_certificate    = true
-						ssl_certificate_host      = "logs.example.com"
-						enable_buffering_proxy    = true
-						buffering_proxy_listen_on = "0.0.0.0:80"
-					}
-
-					configuration {
-						logs_sample_rate   = 100
-						traces_sample_rate = 50
-						vrl_transformation = ".level = downcase!(.level)"
-					}
-				}
-				`, name, platform),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("logtail_collector.this", "id"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.#", "1"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_http_basic_auth", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.http_basic_auth_username", "proxy_user"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.http_basic_auth_password", "proxy_pass"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_ssl_certificate", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.ssl_certificate_host", "logs.example.com"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.enable_buffering_proxy", "true"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "proxy_config.0.buffering_proxy_listen_on", "0.0.0.0:80"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.#", "1"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.logs_sample_rate", "100"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.traces_sample_rate", "50"),
-					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.vrl_transformation", ".level = downcase!(.level)"),
 				),
 			},
 		},


### PR DESCRIPTION
After Collector simplification, the `proxy` platform option is no longer supported.

Cleaning up the Terrafomer provider accordingly.