### PR TITLE
T-17203 Add multi_select_with_sql to variable types with sql_definition

### DIFF
--- a/docs/data-sources/dashboard_chart.md
+++ b/docs/data-sources/dashboard_chart.md
@@ -29,7 +29,7 @@ data "logtail_dashboard_chart" "request_rate" {
 
 ### Read-Only
 
-- `chart_type` (String) The type of chart (e.g., 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', 'anomalies_chart').
+- `chart_type` (String) The type of chart: 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', or 'anomalies_chart'.
 - `created_at` (String) The time when this chart was created.
 - `description` (String) The description of this chart.
 - `h` (Number) The height of this chart in grid units.

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -43,10 +43,10 @@ This resource allows you to create and manage dashboards. Use 'data' for import 
 Required:
 
 - `name` (String) The name of the variable (used as {{name}} in queries).
-- `variable_type` (String) The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', or 'select_with_sql'.
+- `variable_type` (String) The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.
 
 Optional:
 
 - `default_values` (List of String) Default selected values for the variable.
-- `sql_definition` (String) SQL definition for 'sql_expression' or 'select_with_sql' type variables.
+- `sql_definition` (String) SQL definition for 'select_with_sql' or 'multi_select_with_sql' type variables.
 - `values` (List of String) Predefined values for 'select_value' type variables.

--- a/docs/resources/dashboard_chart.md
+++ b/docs/resources/dashboard_chart.md
@@ -52,7 +52,7 @@ resource "logtail_dashboard_chart" "error_count" {
 
 ### Required
 
-- `chart_type` (String) The type of chart (e.g., 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', 'anomalies_chart').
+- `chart_type` (String) The type of chart: 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', or 'anomalies_chart'.
 - `dashboard_id` (String) The ID of the dashboard this chart belongs to.
 - `name` (String) The name of this chart.
 - `query` (Block List, Min: 1) The queries for this chart. At least one query is required. (see [below for nested schema](#nestedblock--query))

--- a/docs/resources/exploration.md
+++ b/docs/resources/exploration.md
@@ -78,10 +78,10 @@ Read-Only:
 Required:
 
 - `name` (String) The name of the variable (used as {{name}} in queries).
-- `variable_type` (String) The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', or 'select_with_sql'.
+- `variable_type` (String) The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.
 
 Optional:
 
 - `default_values` (List of String) Default selected values for the variable.
-- `sql_definition` (String) SQL definition for 'sql_expression' or 'select_with_sql' type variables.
+- `sql_definition` (String) SQL definition for 'select_with_sql' or 'multi_select_with_sql' type variables.
 - `values` (List of String) Predefined values for 'select_value' type variables.

--- a/docs/resources/exploration.md
+++ b/docs/resources/exploration.md
@@ -40,7 +40,7 @@ This resource allows you to create, modify, and delete Explorations in Better St
 
 Required:
 
-- `chart_type` (String) The type of chart (e.g., 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart').
+- `chart_type` (String) The type of chart: 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', or 'anomalies_chart'.
 
 Optional:
 

--- a/internal/provider/alert_shared.go
+++ b/internal/provider/alert_shared.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
@@ -39,15 +40,17 @@ var alertSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"alert_type": {
-		Description: "The type of alert: 'threshold', 'relative', or 'anomaly_rrcf'.",
-		Type:        schema.TypeString,
-		Required:    true,
+		Description:  "The type of alert: 'threshold', 'relative', or 'anomaly_rrcf'.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"threshold", "relative", "anomaly_rrcf"}, false),
 	},
 	"operator": {
-		Description: "The comparison operator. For threshold: 'equal', 'not_equal', 'higher_than', 'higher_than_or_equal', 'lower_than', 'lower_than_or_equal'. For relative: 'increases_by', 'decreases_by', 'changes_by'. Not required for anomaly alerts.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
+		Description:  "The comparison operator. For threshold: 'equal', 'not_equal', 'higher_than', 'higher_than_or_equal', 'lower_than', 'lower_than_or_equal'. For relative: 'increases_by', 'decreases_by', 'changes_by'. Not required for anomaly alerts.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"equal", "not_equal", "higher_than", "higher_than_or_equal", "lower_than", "lower_than_or_equal", "increases_by", "decreases_by", "changes_by"}, false),
 	},
 	"value": {
 		Description: "The numeric threshold value. Required for threshold and relative alerts.",
@@ -105,10 +108,11 @@ var alertSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"source_mode": {
-		Description: "Source selection mode: 'source_variable', 'platforms_single_source', or 'platforms_all_sources'.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
+		Description:  "Source selection mode: 'source_variable', 'platforms_single_source', or 'platforms_all_sources'.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"source_variable", "platforms_single_source", "platforms_all_sources"}, false),
 	},
 	"source_platforms": {
 		Description: "Platform filters (used when source_mode is 'platforms_*').",
@@ -172,10 +176,11 @@ var alertSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"anomaly_trigger": {
-		Description: "Anomaly trigger mode: 'any', 'higher', or 'lower' (only for 'anomaly_rrcf' type).",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
+		Description:  "Anomaly trigger mode: 'any', 'higher', or 'lower' (only for 'anomaly_rrcf' type).",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"any", "higher", "lower"}, false),
 	},
 	"paused_reason": {
 		Description: "Read-only field explaining why the alert is paused (e.g., 'Manually paused', complexity issues, too many failures).",

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var dashboardSchema = map[string]*schema.Schema{
@@ -96,9 +97,10 @@ var dashboardSchema = map[string]*schema.Schema{
 					Required:    true,
 				},
 				"variable_type": {
-					Description: "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.",
-					Type:        schema.TypeString,
-					Required:    true,
+					Description:  "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"source", "string", "number", "date", "datetime", "boolean", "sql_expression", "select_value", "select_with_sql", "multi_select_with_sql"}, false),
 				},
 				"values": {
 					Description: "Predefined values for 'select_value' type variables.",

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -96,7 +96,7 @@ var dashboardSchema = map[string]*schema.Schema{
 					Required:    true,
 				},
 				"variable_type": {
-					Description: "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', or 'select_with_sql'.",
+					Description: "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.",
 					Type:        schema.TypeString,
 					Required:    true,
 				},
@@ -115,7 +115,7 @@ var dashboardSchema = map[string]*schema.Schema{
 					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
 				"sql_definition": {
-					Description: "SQL definition for 'sql_expression' or 'select_with_sql' type variables.",
+					Description: "SQL definition for 'select_with_sql' or 'multi_select_with_sql' type variables.",
 					Type:        schema.TypeString,
 					Optional:    true,
 					Computed:    true,

--- a/internal/provider/resource_dashboard_chart.go
+++ b/internal/provider/resource_dashboard_chart.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var dashboardChartSchema = map[string]*schema.Schema{
@@ -25,9 +26,10 @@ var dashboardChartSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"chart_type": {
-		Description: "The type of chart (e.g., 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', 'anomalies_chart').",
-		Type:        schema.TypeString,
-		Required:    true,
+		Description:  "The type of chart: 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', or 'anomalies_chart'.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"line_chart", "bar_chart", "pie_chart", "number_chart", "table_chart", "tail_chart", "static_text_chart", "scatter_chart", "gauge_chart", "heatmap_chart", "map_chart", "text_chart", "funnel_chart", "anomalies_chart"}, false),
 	},
 	"name": {
 		Description: "The name of this chart.",
@@ -109,9 +111,10 @@ var dashboardChartSchema = map[string]*schema.Schema{
 					Computed:    true,
 				},
 				"query_type": {
-					Description: "The type of query: 'sql_expression', 'tail_query', or 'static_text'. Note: 'pql_expression', 'query_builder', and 'funnel_query' are read-only.",
-					Type:        schema.TypeString,
-					Required:    true,
+					Description:  "The type of query: 'sql_expression', 'tail_query', or 'static_text'. Note: 'pql_expression', 'query_builder', and 'funnel_query' are read-only.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"sql_expression", "tail_query", "static_text", "pql_expression", "query_builder", "funnel_query"}, false),
 				},
 				"sql_query": {
 					Description: "The SQL query string. Required when query_type is 'sql_expression'.",

--- a/internal/provider/resource_exploration.go
+++ b/internal/provider/resource_exploration.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var explorationSchema = map[string]*schema.Schema{
@@ -84,9 +85,10 @@ var explorationSchema = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"chart_type": {
-					Description: "The type of chart (e.g., 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart').",
-					Type:        schema.TypeString,
-					Required:    true,
+					Description:  "The type of chart: 'line_chart', 'bar_chart', 'pie_chart', 'number_chart', 'table_chart', 'tail_chart', 'static_text_chart', 'scatter_chart', 'gauge_chart', 'heatmap_chart', 'map_chart', 'text_chart', 'funnel_chart', or 'anomalies_chart'.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"line_chart", "bar_chart", "pie_chart", "number_chart", "table_chart", "tail_chart", "static_text_chart", "scatter_chart", "gauge_chart", "heatmap_chart", "map_chart", "text_chart", "funnel_chart", "anomalies_chart"}, false),
 				},
 				"name": {
 					Description: "The name of the chart. Automatically set to the exploration name by the API.",
@@ -146,9 +148,10 @@ var explorationSchema = map[string]*schema.Schema{
 					Optional:    true,
 				},
 				"query_type": {
-					Description: "The type of query: 'sql_expression', 'tail_query', or 'static_text'. Note: 'pql_expression', 'query_builder', and 'funnel_query' are read-only.",
-					Type:        schema.TypeString,
-					Required:    true,
+					Description:  "The type of query: 'sql_expression', 'tail_query', or 'static_text'. Note: 'pql_expression', 'query_builder', and 'funnel_query' are read-only.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"sql_expression", "tail_query", "static_text", "pql_expression", "query_builder", "funnel_query"}, false),
 				},
 				"sql_query": {
 					Description: "The SQL query string. Required when query_type is 'sql_expression'.",
@@ -186,9 +189,10 @@ var explorationSchema = map[string]*schema.Schema{
 					Required:    true,
 				},
 				"variable_type": {
-					Description: "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.",
-					Type:        schema.TypeString,
-					Required:    true,
+					Description:  "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"source", "string", "number", "date", "datetime", "boolean", "sql_expression", "select_value", "select_with_sql", "multi_select_with_sql"}, false),
 				},
 				"values": {
 					Description: "Predefined values for 'select_value' type variables.",

--- a/internal/provider/resource_exploration.go
+++ b/internal/provider/resource_exploration.go
@@ -186,7 +186,7 @@ var explorationSchema = map[string]*schema.Schema{
 					Required:    true,
 				},
 				"variable_type": {
-					Description: "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', or 'select_with_sql'.",
+					Description: "The type of variable: 'source', 'string', 'number', 'date', 'datetime', 'boolean', 'sql_expression', 'select_value', 'select_with_sql', or 'multi_select_with_sql'.",
 					Type:        schema.TypeString,
 					Required:    true,
 				},
@@ -203,7 +203,7 @@ var explorationSchema = map[string]*schema.Schema{
 					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
 				"sql_definition": {
-					Description: "SQL definition for 'sql_expression' or 'select_with_sql' type variables.",
+					Description: "SQL definition for 'select_with_sql' or 'multi_select_with_sql' type variables.",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},


### PR DESCRIPTION
The `multi_select_with_sql` variable type was added in the API.

Also adds plan-phase validation for enum fields to improve DX.