### PR TITLE
[T-17349] [Opus] Document allowed confirmation_period values

### DIFF
--- a/docs/data-sources/dashboard_alert.md
+++ b/docs/data-sources/dashboard_alert.md
@@ -37,7 +37,7 @@ data "logtail_dashboard_alert" "high_error_rate" {
 - `anomaly_trigger` (String) Anomaly trigger mode: 'any', 'higher', or 'lower' (only for 'anomaly_rrcf' type).
 - `call` (Boolean) Enable phone call notifications.
 - `check_period` (Number) How often to check the alert condition in seconds.
-- `confirmation_period` (Number) The confirmation delay in seconds before triggering (required, >= 0).
+- `confirmation_period` (Number) The confirmation delay in seconds before triggering. Must be one of: 0, 30, 60, 120, 300, 600, 1800, 3600, 7200, 14400.
 - `created_at` (String) The time when this alert was created.
 - `critical_alert` (Boolean) Mark as critical alert (bypasses quiet hours).
 - `email` (Boolean) Enable email notifications.

--- a/docs/data-sources/exploration_alert.md
+++ b/docs/data-sources/exploration_alert.md
@@ -28,7 +28,7 @@ This data source allows you to get information about an Alert on an Exploration 
 - `anomaly_trigger` (String) Anomaly trigger mode: 'any', 'higher', or 'lower' (only for 'anomaly_rrcf' type).
 - `call` (Boolean) Enable phone call notifications.
 - `check_period` (Number) How often to check the alert condition in seconds.
-- `confirmation_period` (Number) The confirmation delay in seconds before triggering (required, >= 0).
+- `confirmation_period` (Number) The confirmation delay in seconds before triggering. Must be one of: 0, 30, 60, 120, 300, 600, 1800, 3600, 7200, 14400.
 - `created_at` (String) The time when this alert was created.
 - `critical_alert` (Boolean) Mark as critical alert (bypasses quiet hours).
 - `email` (Boolean) Enable email notifications.

--- a/docs/resources/dashboard_alert.md
+++ b/docs/resources/dashboard_alert.md
@@ -45,7 +45,7 @@ resource "logtail_dashboard_alert" "high_error_rate" {
 - `anomaly_trigger` (String) Anomaly trigger mode: 'any', 'higher', or 'lower' (only for 'anomaly_rrcf' type).
 - `call` (Boolean) Enable phone call notifications.
 - `check_period` (Number) How often to check the alert condition in seconds.
-- `confirmation_period` (Number) The confirmation delay in seconds before triggering (required, >= 0).
+- `confirmation_period` (Number) The confirmation delay in seconds before triggering. Must be one of: 0, 30, 60, 120, 300, 600, 1800, 3600, 7200, 14400.
 - `critical_alert` (Boolean) Mark as critical alert (bypasses quiet hours).
 - `email` (Boolean) Enable email notifications.
 - `escalation_target` (Block List, Max: 1) The escalation target for this alert. Specify either team_id/team_name OR policy_id/policy_name. (see [below for nested schema](#nestedblock--escalation_target))

--- a/docs/resources/exploration_alert.md
+++ b/docs/resources/exploration_alert.md
@@ -28,7 +28,7 @@ This resource allows you to create, modify, and delete Alerts on Explorations in
 - `anomaly_trigger` (String) Anomaly trigger mode: 'any', 'higher', or 'lower' (only for 'anomaly_rrcf' type).
 - `call` (Boolean) Enable phone call notifications.
 - `check_period` (Number) How often to check the alert condition in seconds.
-- `confirmation_period` (Number) The confirmation delay in seconds before triggering (required, >= 0).
+- `confirmation_period` (Number) The confirmation delay in seconds before triggering. Must be one of: 0, 30, 60, 120, 300, 600, 1800, 3600, 7200, 14400.
 - `critical_alert` (Boolean) Mark as critical alert (bypasses quiet hours).
 - `email` (Boolean) Enable email notifications.
 - `escalation_target` (Block List, Max: 1) The escalation target for this alert. Specify either team_id/team_name OR policy_id/policy_name. (see [below for nested schema](#nestedblock--escalation_target))

--- a/internal/provider/alert_shared.go
+++ b/internal/provider/alert_shared.go
@@ -71,7 +71,7 @@ var alertSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"confirmation_period": {
-		Description: "The confirmation delay in seconds before triggering (required, >= 0).",
+		Description: "The confirmation delay in seconds before triggering. Must be one of: 0, 30, 60, 120, 300, 600, 1800, 3600, 7200, 14400.",
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Computed:    true,


### PR DESCRIPTION
Companion to [BetterStackHQ/logtail#13728](https://github.com/BetterStackHQ/logtail/pull/13728) — docs-only change in this repo.

---

## Summary
- Add `ChartAlert::VALID_CONFIRMATION_PERIODS` plus an inclusion validator gated on `new_record? || confirmation_period_changed?`, closing the gap that let non-standard values (e.g. `confirmation_period: 180`) enter via JSON import or `/api/v2/alerts`.
- Existing rows keep working: legacy alerts with non-standard values stay editable on unrelated fields — the validator only fires when the column is actually being changed (or on a new record).
- First commit on the branch is the prior "(custom)" UI display fix; this commit closes the data-entry hole. Happy to drop the display commit and keep only the validation if you prefer a single-commit PR — just say the word.

## Test plan
- [ ] `rails test test/models/chart_alert_test.rb` — new cases for valid list, rejection on change, legacy editability, new-record rejection
- [ ] `rails test test/services/dashboards/importer_test.rb` — new case asserting import fails with "Confirmation period must be one of"
- [ ] `rails test test/controllers/api/v2/dashboard_alerts_controller_test.rb` — new cases for create + update returning 422
- [ ] Manual: import a dashboard JSON with `confirmation_period: 180` → validation error; API POST with 180 → 422
- [ ] Manual: existing alert with legacy non-standard period stays editable when only unrelated fields change

---

## Terraform-provider scope
No schema validation added (API remains the source of truth, avoids drift). Only the description + regenerated `.md` docs. Please run `make gen` locally to confirm my hand-edits match what the generator produces — I didn't have `go`/`terraform` on the box where this was staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
