### PR TITLE
T-17482: Expose correlate_with_source_id on errors_application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.11.3
+VERSION := 10.12.2
 .PHONY: test build
 
 help:

--- a/docs/data-sources/errors_application.md
+++ b/docs/data-sources/errors_application.md
@@ -24,6 +24,7 @@ This Data Source allows you to look up existing Errors applications using their 
 - `application_group_id` (Number) ID of the application group this application belongs to. Set to `0` to remove from a group.
 - `code_mapping_source_root` (String) Source code root path that replaces the stack trace root prefix. Used to map container or build paths to the corresponding repository paths for git blame.
 - `code_mapping_stack_root` (String) Stack trace root path prefix to match. When a stack trace file starts with this prefix, it will be replaced with the source code root to map to the correct repository path.
+- `correlate_with_source_id` (Number) ID of an existing source to correlate errors from this application with, for log and trace correlation. Cannot be changed after the application is created.
 - `created_at` (String) The time when this application was created.
 - `custom_bucket` (List of Object) Optional custom bucket configuration for the application. When provided, all fields (name, endpoint, access_key_id, secret_access_key) are required. (see [below for nested schema](#nestedatt--custom_bucket))
 - `data_region` (String) Data region or cluster name where application data will be stored. If omitted, the default data region for your team will be used.

--- a/docs/resources/errors_application.md
+++ b/docs/resources/errors_application.md
@@ -118,6 +118,7 @@ This resource allows you to create, modify, and delete your Errors applications.
 ### Optional
 
 - `application_group_id` (Number) ID of the application group this application belongs to. Set to `0` to remove from a group.
+- `canonical_parent_id` (Number) ID of an existing source to correlate errors with for log and trace correlation. Cannot be changed after creation.
 - `code_mapping_source_root` (String) Source code root path that replaces the stack trace root prefix. Used to map container or build paths to the corresponding repository paths for git blame.
 - `code_mapping_stack_root` (String) Stack trace root path prefix to match. When a stack trace file starts with this prefix, it will be replaced with the source code root to map to the correct repository path.
 - `custom_bucket` (Block List, Max: 1) Optional custom bucket configuration for the application. When provided, all fields (name, endpoint, access_key_id, secret_access_key) are required. (see [below for nested schema](#nestedblock--custom_bucket))

--- a/docs/resources/errors_application.md
+++ b/docs/resources/errors_application.md
@@ -118,9 +118,9 @@ This resource allows you to create, modify, and delete your Errors applications.
 ### Optional
 
 - `application_group_id` (Number) ID of the application group this application belongs to. Set to `0` to remove from a group.
-- `canonical_parent_id` (Number) ID of an existing source to correlate errors with for log and trace correlation. Cannot be changed after creation.
 - `code_mapping_source_root` (String) Source code root path that replaces the stack trace root prefix. Used to map container or build paths to the corresponding repository paths for git blame.
 - `code_mapping_stack_root` (String) Stack trace root path prefix to match. When a stack trace file starts with this prefix, it will be replaced with the source code root to map to the correct repository path.
+- `correlate_with_source_id` (Number) ID of an existing source to correlate errors from this application with, for log and trace correlation. Cannot be changed after the application is created.
 - `custom_bucket` (Block List, Max: 1) Optional custom bucket configuration for the application. When provided, all fields (name, endpoint, access_key_id, secret_access_key) are required. (see [below for nested schema](#nestedblock--custom_bucket))
 - `data_region` (String) Data region or cluster name where application data will be stored. If omitted, the default data region for your team will be used.
 - `errors_retention` (Number) Error data retention period in days. Default retention is 90 days.

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -140,6 +140,17 @@ resource "logtail_collector" "with_databases" {
 }
 
 # ---------------------------------------------------------------------------
+# Errors application correlated with the Docker collector for log and trace
+# correlation. correlate_with_source_id cannot be changed after the
+# application is created.
+# ---------------------------------------------------------------------------
+resource "logtail_errors_application" "correlated_with_docker_collector" {
+  name                     = "E2E Correlated App ${random_pet.unique.id}"
+  platform                 = "python_errors"
+  correlate_with_source_id = logtail_collector.docker_basic.source_id
+}
+
+# ---------------------------------------------------------------------------
 # Data source to look up a collector created above
 # ---------------------------------------------------------------------------
 data "logtail_collector" "existing" {

--- a/examples/collector/versions.tf
+++ b/examples/collector/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 10.9.3"
+      version = ">= 10.12.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -243,11 +243,10 @@ var errorsApplicationSchema = map[string]*schema.Schema{
 			return false
 		},
 	},
-	"canonical_parent_id": {
-		Description: "ID of an existing source to correlate errors with for log and trace correlation. Cannot be changed after creation.",
+	"correlate_with_source_id": {
+		Description: "ID of an existing source to correlate errors from this application with, for log and trace correlation. Cannot be changed after the application is created.",
 		Type:        schema.TypeInt,
 		Optional:    true,
-		ForceNew:    true,
 	},
 	"custom_bucket": {
 		Description: "Optional custom bucket configuration for the application. When provided, all fields (name, endpoint, access_key_id, secret_access_key) are required.",
@@ -319,7 +318,7 @@ type errorsApplication struct {
 	CodeMappingStackRoot  *string             `json:"code_mapping_stack_root,omitempty"`
 	CodeMappingSourceRoot *string             `json:"code_mapping_source_root,omitempty"`
 	ApplicationGroupID    *int                `json:"application_group_id,omitempty"`
-	CanonicalParentID     *int                `json:"canonical_parent_id,omitempty"`
+	CorrelateWithSourceID *int                `json:"correlate_with_source_id,omitempty"`
 	CustomBucket          *sourceCustomBucket `json:"custom_bucket,omitempty"`
 }
 
@@ -352,7 +351,7 @@ func errorsApplicationRef(in *errorsApplication) []struct {
 		{k: "code_mapping_stack_root", v: &in.CodeMappingStackRoot},
 		{k: "code_mapping_source_root", v: &in.CodeMappingSourceRoot},
 		{k: "application_group_id", v: &in.ApplicationGroupID},
-		{k: "canonical_parent_id", v: &in.CanonicalParentID},
+		{k: "correlate_with_source_id", v: &in.CorrelateWithSourceID},
 	}
 }
 
@@ -482,6 +481,10 @@ func errorsApplicationDelete(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func validateErrorsApplication(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if diff.Id() != "" && diff.HasChange("correlate_with_source_id") {
+		return fmt.Errorf("correlate_with_source_id cannot be changed after the application is created")
+	}
+
 	if err := validateCustomBucketRemoval(ctx, diff, v); err != nil {
 		return err
 	}

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -243,6 +243,12 @@ var errorsApplicationSchema = map[string]*schema.Schema{
 			return false
 		},
 	},
+	"canonical_parent_id": {
+		Description: "ID of an existing source to correlate errors with for log and trace correlation. Cannot be changed after creation.",
+		Type:        schema.TypeInt,
+		Optional:    true,
+		ForceNew:    true,
+	},
 	"custom_bucket": {
 		Description: "Optional custom bucket configuration for the application. When provided, all fields (name, endpoint, access_key_id, secret_access_key) are required.",
 		Type:        schema.TypeList,
@@ -313,6 +319,7 @@ type errorsApplication struct {
 	CodeMappingStackRoot  *string             `json:"code_mapping_stack_root,omitempty"`
 	CodeMappingSourceRoot *string             `json:"code_mapping_source_root,omitempty"`
 	ApplicationGroupID    *int                `json:"application_group_id,omitempty"`
+	CanonicalParentID     *int                `json:"canonical_parent_id,omitempty"`
 	CustomBucket          *sourceCustomBucket `json:"custom_bucket,omitempty"`
 }
 
@@ -345,6 +352,7 @@ func errorsApplicationRef(in *errorsApplication) []struct {
 		{k: "code_mapping_stack_root", v: &in.CodeMappingStackRoot},
 		{k: "code_mapping_source_root", v: &in.CodeMappingSourceRoot},
 		{k: "application_group_id", v: &in.ApplicationGroupID},
+		{k: "canonical_parent_id", v: &in.CanonicalParentID},
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds the `correlate_with_source_id` attribute to the `logtail_errors_application` resource so errors applications can be linked to an existing source for log and trace correlation when created via Terraform.
- Blocks changes to the attribute after creation (returns a validation error, like `data_region` on `logtail_source`) — does not silently destroy and recreate the application or its retained data.

## Test plan
- [x] Wait for upstread API changes
- [x] Apply a config setting `correlate_with_source_id` and confirm the application is created with the link
- [x] Confirm changing `correlate_with_source_id` returns a clear error and does NOT recreate the resource