### PR TITLE
T-17376 Require ssl_mode (postgres) and tls (mysql) on collector_target at plan time

### DIFF
--- a/internal/provider/resource_collector_target.go
+++ b/internal/provider/resource_collector_target.go
@@ -238,7 +238,7 @@ func validateCollectorTarget(ctx context.Context, diff *schema.ResourceDiff, v i
 			return fmt.Errorf("scheme is required for elasticsearch")
 		}
 		// Mirror the API's per-kind required fields (telemetry: CollectorTarget#validate_settings_for_kind)
-		// so a missing ssl_mode/tls is caught at plan time instead of as a 422 on apply (T-17376).
+		// so a missing ssl_mode/tls is caught at plan time instead of as a 422 on apply.
 		if kind == "postgres" && diff.Get("ssl_mode").(string) == "" {
 			return fmt.Errorf("ssl_mode is required for kind %q", kind)
 		}

--- a/internal/provider/resource_collector_target.go
+++ b/internal/provider/resource_collector_target.go
@@ -237,6 +237,14 @@ func validateCollectorTarget(ctx context.Context, diff *schema.ResourceDiff, v i
 		if kind == "elasticsearch" && diff.Get("scheme").(string) == "" {
 			return fmt.Errorf("scheme is required for elasticsearch")
 		}
+		// Mirror the API's per-kind required fields (telemetry: CollectorTarget#validate_settings_for_kind)
+		// so a missing ssl_mode/tls is caught at plan time instead of as a 422 on apply (T-17376).
+		if kind == "postgres" && diff.Get("ssl_mode").(string) == "" {
+			return fmt.Errorf("ssl_mode is required for kind %q", kind)
+		}
+		if kind == "mysql" && diff.Get("tls").(string) == "" {
+			return fmt.Errorf("tls is required for kind %q", kind)
+		}
 	}
 
 	for _, field := range collectorTargetCheckableFields {

--- a/internal/provider/resource_collector_target_test.go
+++ b/internal/provider/resource_collector_target_test.go
@@ -481,6 +481,30 @@ func TestResourceCollectorTargetValidation(t *testing.T) {
 			errorRe: `scheme is required for elasticsearch`,
 		},
 		{
+			name: "postgres without ssl_mode",
+			config: `
+			resource "logtail_collector_target" "x" {
+				collector_id = "1"
+				kind         = "postgres"
+				host         = "pg.example.com"
+				port         = 5432
+			}
+			`,
+			errorRe: `ssl_mode is required for kind "postgres"`,
+		},
+		{
+			name: "mysql without tls",
+			config: `
+			resource "logtail_collector_target" "x" {
+				collector_id = "1"
+				kind         = "mysql"
+				host         = "m.example.com"
+				port         = 3306
+			}
+			`,
+			errorRe: `tls is required for kind "mysql"`,
+		},
+		{
 			name: "unknown kind",
 			config: `
 			resource "logtail_collector_target" "x" {


### PR DESCRIPTION
The collector API requires ssl_mode for postgres targets and tls for mysql targets (telemetry: `CollectorTarget#validate_settings_for_kind`). The provider only enforced the analogous elasticsearch `scheme` rule, so a postgres target without ssl_mode passed `terraform plan` and then failed at apply with a 422 ("ssl_mode can't be blank").

Add the matching per-kind required-field checks to validateCollectorTarget so the error is surfaced at plan time.