### PR TITLE
Reject changing team_name after a resource is created

### DIFF
--- a/docs/data-sources/collector.md
+++ b/docs/data-sources/collector.md
@@ -50,7 +50,7 @@ When importing an existing collector, leave `data_region` unset in your configur
 - `source_vrl_transformation` (String) Server-side VRL transformation that runs during ingestion on Better Stack. Use this for enrichment, routing, or light normalization that doesn't involve sensitive data. For PII redaction and sensitive data filtering, prefer `configuration.vrl_transformation` which runs on the collector host and ensures raw data never leaves your network. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
 - `status` (String) The current status of this collector.
 - `team_id` (String) The team ID for this resource.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `updated_at` (String) The time when this collector was last updated.
 - `user_vector_config` (String) Custom Vector YAML configuration for additional sources and transforms beyond the built-in component toggles. Must not contain `command:` directives.
 

--- a/docs/data-sources/dashboard_group.md
+++ b/docs/data-sources/dashboard_group.md
@@ -29,5 +29,5 @@ data "logtail_dashboard_group" "production" {
 
 - `created_at` (String) The time when this dashboard group was created.
 - `id` (String) The ID of this dashboard group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `updated_at` (String) The time when this dashboard group was updated.

--- a/docs/data-sources/errors_application.md
+++ b/docs/data-sources/errors_application.md
@@ -131,7 +131,7 @@ When importing an existing application, leave `data_region` unset in your config
     - `wsgi_errors`
 - `table_name` (String) The table name generated for this application.
 - `team_id` (String) The team ID for this resource.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `token` (String) The token of this application. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this application was updated.
 

--- a/docs/data-sources/errors_application_group.md
+++ b/docs/data-sources/errors_application_group.md
@@ -24,5 +24,5 @@ This Data Source allows you to look up existing Errors application groups using 
 - `created_at` (String) The time when this application group was created.
 - `id` (String) The ID of this application group.
 - `sort_index` (Number) The sort index of this application group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `updated_at` (String) The time when this application group was updated.

--- a/docs/data-sources/exploration.md
+++ b/docs/data-sources/exploration.md
@@ -28,7 +28,7 @@ This data source allows you to get information about an Exploration in Better St
 - `exploration_group_id` (Number) The ID of the exploration group this exploration belongs to. Use 0 to remove from group.
 - `id` (String) The ID of this exploration.
 - `query` (List of Object) The queries for this exploration. At least one query is required. (see [below for nested schema](#nestedatt--query))
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `updated_at` (String) The time when this exploration was updated.
 - `variable` (List of Object) Variables for this exploration. Default variables (time, start_time, end_time, source) are auto-created. (see [below for nested schema](#nestedatt--variable))
 

--- a/docs/data-sources/exploration_group.md
+++ b/docs/data-sources/exploration_group.md
@@ -23,5 +23,5 @@ This data source allows you to get information about an Exploration Group in Bet
 
 - `created_at` (String) The time when this exploration group was created.
 - `id` (String) The ID of this exploration group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `updated_at` (String) The time when this exploration group was updated.

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -96,7 +96,7 @@ When importing an existing source, leave `data_region` unset in your configurati
 - `skip_ssl_verify` (Boolean) Should the scraper skip SSL certificate verification? Enable for endpoints with self-signed or invalid certificates.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
 - `team_id` (String) The team ID for this resource. Can be used with table_name in [Query API](https://betterstack.com/docs/logs/query-api/connect-remotely/).
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `token` (String) The token of this source. This token is used to identify and route the data you will send to Better Stack.
 - `updated_at` (String) The time when this monitor group was updated.
 - `vrl_transformation` (String) VRL transformation that runs on Better Stack's servers during ingestion. Note: data has already left your infrastructure at this point. For transformations that must run before data leaves your network (e.g. PII redaction), use `logtail_collector` with `configuration.vrl_transformation` instead. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).

--- a/docs/data-sources/source_group.md
+++ b/docs/data-sources/source_group.md
@@ -24,5 +24,5 @@ This data source allows you to get information about a Source Group. For more in
 - `created_at` (String) The time when this source group was created.
 - `id` (String) The ID of this source group.
 - `sort_index` (Number) The sort index of this source group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `updated_at` (String) The time when this source group was updated.

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -71,7 +71,7 @@ When importing an existing collector, leave `data_region` unset in your configur
 - `note` (String) A description or note about this collector.
 - `source_group_id` (Number) The ID of the source group (folder) this collector belongs to. Set to `0` to remove from a group.
 - `source_vrl_transformation` (String) Server-side VRL transformation that runs during ingestion on Better Stack. Use this for enrichment, routing, or light normalization that doesn't involve sensitive data. For PII redaction and sensitive data filtering, prefer `configuration.vrl_transformation` which runs on the collector host and ensures raw data never leaves your network. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `user_vector_config` (String) Custom Vector YAML configuration for additional sources and transforms beyond the built-in component toggles. Must not contain `command:` directives.
 
 ### Read-Only

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -27,7 +27,7 @@ This resource allows you to create and manage dashboards. Use 'data' for import 
 - `date_range_to` (String) The end of the date range (e.g., 'now').
 - `refresh_interval` (Number) The auto-refresh interval in seconds.
 - `source_eligibility_sql` (String) SQL expression to filter eligible sources.
-- `team_name` (String) The team name to associate with the dashboard when using a global API token.
+- `team_name` (String) The team name to associate with the dashboard when using a global API token. You can't update this value later.
 - `variable` (Block List) Variables for this dashboard. Default variables (time, start_time, end_time, source) are auto-created. (see [below for nested schema](#nestedblock--variable))
 
 ### Read-Only

--- a/docs/resources/dashboard_group.md
+++ b/docs/resources/dashboard_group.md
@@ -27,7 +27,7 @@ resource "logtail_dashboard_group" "production" {
 
 ### Optional
 
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/errors_application.md
+++ b/docs/resources/errors_application.md
@@ -126,7 +126,7 @@ This resource allows you to create, modify, and delete your Errors applications.
 When importing an existing application, leave `data_region` unset in your configuration - Terraform reads it from the API. Pinning it to an identifier that differs from the stored cluster name produces a spurious `data_region cannot be changed after application is created` error.
 - `errors_retention` (Number) Error data retention period in days. Default retention is 90 days.
 - `ingesting_paused` (Boolean) This property allows you to temporarily pause data ingesting for this application.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/errors_application_group.md
+++ b/docs/resources/errors_application_group.md
@@ -22,7 +22,7 @@ This resource allows you to create, modify, and delete your Errors application g
 ### Optional
 
 - `sort_index` (Number) The sort index of this application group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/exploration.md
+++ b/docs/resources/exploration.md
@@ -26,7 +26,7 @@ This resource allows you to create, modify, and delete Explorations in Better St
 - `date_range_from` (String) The start of the date range (e.g., 'now-3h', 'now-24h').
 - `date_range_to` (String) The end of the date range (e.g., 'now').
 - `exploration_group_id` (Number) The ID of the exploration group this exploration belongs to. Use 0 to remove from group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `variable` (Block List) Variables for this exploration. Default variables (time, start_time, end_time, source) are auto-created. (see [below for nested schema](#nestedblock--variable))
 
 ### Read-Only

--- a/docs/resources/exploration_group.md
+++ b/docs/resources/exploration_group.md
@@ -21,7 +21,7 @@ This resource allows you to create, modify, and delete Exploration Groups. Explo
 
 ### Optional
 
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -91,7 +91,7 @@ When importing an existing source, leave `data_region` unset in your configurati
 - `scrape_urls` (List of String) For scrape platform types, the set of urls to scrape.
 - `skip_ssl_verify` (Boolean) Should the scraper skip SSL certificate verification? Enable for endpoints with self-signed or invalid certificates.
 - `source_group_id` (Number) The ID of the source group this source belongs to.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `vrl_transformation` (String) VRL transformation that runs on Better Stack's servers during ingestion. Note: data has already left your infrastructure at this point. For transformations that must run before data leaves your network (e.g. PII redaction), use `logtail_collector` with `configuration.vrl_transformation` instead. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
 
 ### Read-Only

--- a/docs/resources/source_group.md
+++ b/docs/resources/source_group.md
@@ -22,7 +22,7 @@ This resource allows you to create, modify, and delete your Source Groups. For m
 ### Optional
 
 - `sort_index` (Number) The sort index of this source group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/internal/provider/resource_collector.go
+++ b/internal/provider/resource_collector.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -60,15 +61,7 @@ var collectorSchema = map[string]*schema.Schema{
 		Optional:    false,
 		Computed:    true,
 	},
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"team_id": {
 		Description: "The team ID for this resource.",
 		Type:        schema.TypeString,
@@ -640,7 +633,7 @@ func newCollectorResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateCollector,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateCollector),
 		Description:   "This resource allows you to create, modify, and delete Better Stack Collectors. For more information about the Collectors API check https://betterstack.com/docs/logs/api/collectors/",
 		Schema:        collectorSchema,
 	}

--- a/internal/provider/resource_dashboard.go
+++ b/internal/provider/resource_dashboard.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -30,7 +31,7 @@ var dashboardSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"team_name": {
-		Description: "The team name to associate with the dashboard when using a global API token.",
+		Description: "The team name to associate with the dashboard when using a global API token. You can't update this value later.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Default:     nil,
@@ -183,7 +184,7 @@ func newDashboardResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateDashboard,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateDashboard),
 		Description:   "This resource allows you to create and manage dashboards. Use 'data' for import mode (JSON blob, re-created on change) or individual fields for CRUD mode (updatable). For more information about the Dashboard API check https://betterstack.com/docs/logs/api/dashboards/",
 		Schema:        dashboardSchema,
 	}

--- a/internal/provider/resource_dashboard_group.go
+++ b/internal/provider/resource_dashboard_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var dashboardGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this dashboard group.",
 		Type:        schema.TypeString,
@@ -54,8 +46,9 @@ func newDashboardGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource allows you to create, modify, and delete Dashboard Groups. Dashboard Groups help organize dashboards in Better Stack Telemetry.",
-		Schema:      dashboardGroupSchema,
+		Description:   "This resource allows you to create, modify, and delete Dashboard Groups. Dashboard Groups help organize dashboards in Better Stack Telemetry.",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        dashboardGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -115,15 +116,7 @@ var errorsPlatformTypes = []string{
 }
 
 var errorsApplicationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"team_id": {
 		Description: "The team ID for this resource.",
 		Type:        schema.TypeString,
@@ -300,7 +293,7 @@ func newErrorsApplicationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateErrorsApplication,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateErrorsApplication),
 		Description:   "This resource allows you to create, modify, and delete your Errors applications. For more information about the Errors API check https://betterstack.com/docs/errors/api/applications/create/",
 		Schema:        errorsApplicationSchema,
 	}

--- a/internal/provider/resource_errors_application_group.go
+++ b/internal/provider/resource_errors_application_group.go
@@ -14,15 +14,7 @@ import (
 )
 
 var errorsApplicationGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this application group.",
 		Type:        schema.TypeString,
@@ -62,8 +54,9 @@ func newErrorsApplicationGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource allows you to create, modify, and delete your Errors application groups. For more information about the Errors API check https://betterstack.com/docs/errors/api/applications-groups/create/",
-		Schema:      errorsApplicationGroupSchema,
+		Description:   "This resource allows you to create, modify, and delete your Errors application groups. For more information about the Errors API check https://betterstack.com/docs/errors/api/applications-groups/create/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        errorsApplicationGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_exploration.go
+++ b/internal/provider/resource_exploration.go
@@ -12,15 +12,7 @@ import (
 )
 
 var explorationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this exploration.",
 		Type:        schema.TypeString,
@@ -225,8 +217,9 @@ func newExplorationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource allows you to create, modify, and delete Explorations in Better Stack Telemetry. Explorations are interactive charts with queries and variables.",
-		Schema:      explorationSchema,
+		Description:   "This resource allows you to create, modify, and delete Explorations in Better Stack Telemetry. Explorations are interactive charts with queries and variables.",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        explorationSchema,
 	}
 }
 

--- a/internal/provider/resource_exploration_group.go
+++ b/internal/provider/resource_exploration_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var explorationGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this exploration group.",
 		Type:        schema.TypeString,
@@ -54,8 +46,9 @@ func newExplorationGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource allows you to create, modify, and delete Exploration Groups. Exploration Groups help organize explorations in Better Stack Telemetry.",
-		Schema:      explorationGroupSchema,
+		Description:   "This resource allows you to create, modify, and delete Exploration Groups. Exploration Groups help organize explorations in Better Stack Telemetry.",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        explorationGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -70,15 +71,7 @@ var platformTypes = []string{
 }
 
 var sourceSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"team_id": {
 		Description: "The team ID for this resource. Can be used with table_name in [Query API](https://betterstack.com/docs/logs/query-api/connect-remotely/).",
 		Type:        schema.TypeString,
@@ -312,7 +305,7 @@ func newSourceResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateSource,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateSource),
 		Description:   "This resource allows you to create, modify, and delete your Sources. For more information about the Sources API check https://betterstack.com/docs/logs/api/list-all-existing-sources/",
 		Schema:        sourceSchema,
 	}

--- a/internal/provider/resource_source_group.go
+++ b/internal/provider/resource_source_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var sourceGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this source group.",
 		Type:        schema.TypeString,
@@ -59,8 +51,9 @@ func newSourceGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource allows you to create, modify, and delete your Source Groups. For more information about the Source Groups API check https://betterstack.com/docs/logs/api/",
-		Schema:      sourceGroupSchema,
+		Description:   "This resource allows you to create, modify, and delete your Source Groups. For more information about the Source Groups API check https://betterstack.com/docs/logs/api/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        sourceGroupSchema,
 	}
 }
 

--- a/internal/provider/team_name.go
+++ b/internal/provider/team_name.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// teamNameSchema returns the schema for the team_name attribute shared by every resource that can
+// be created in a specific team using a global API token. The value is only used when the resource
+// is created; afterwards any change is suppressed (see DiffSuppressFunc) and changing it to a
+// different non-empty value is rejected (see validateTeamNameNotChanged).
+func teamNameSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "Used to specify the team the resource should be created in when using global tokens. You can't update this value later.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     nil,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return d.Id() != ""
+		},
+	}
+}
+
+// validateTeamNameNotChanged rejects changing team_name to a different, non-empty value after a
+// resource has been created. team_name only selects the team when the resource is created with a
+// global API token and is ignored afterwards, so silently dropping the change ("No changes") was
+// confusing. Clearing the value remains a silent no-op (the diff is suppressed in teamNameSchema).
+//
+// The change is detected from the raw config and state rather than HasChange, because the
+// DiffSuppressFunc removes team_name from the computed diff before CustomizeDiff runs.
+func validateTeamNameNotChanged(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if diff.Id() == "" {
+		// The resource is being created — team_name is honored.
+		return nil
+	}
+
+	config := diff.GetRawConfig()
+	if config.IsNull() || !config.IsKnown() {
+		return nil
+	}
+	newAttr := config.GetAttr("team_name")
+	if newAttr.IsNull() || !newAttr.IsKnown() {
+		return nil
+	}
+	newName := newAttr.AsString()
+	if newName == "" {
+		// Clearing team_name has no effect, so allow it (the diff is suppressed).
+		return nil
+	}
+
+	oldName := ""
+	if state := diff.GetRawState(); !state.IsNull() && state.IsKnown() {
+		if oldAttr := state.GetAttr("team_name"); !oldAttr.IsNull() && oldAttr.IsKnown() {
+			oldName = oldAttr.AsString()
+		}
+	}
+	if newName != oldName {
+		return fmt.Errorf("team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token")
+	}
+	return nil
+}

--- a/internal/provider/team_name.go
+++ b/internal/provider/team_name.go
@@ -57,7 +57,7 @@ func validateTeamNameNotChanged(ctx context.Context, diff *schema.ResourceDiff, 
 		}
 	}
 	if newName != oldName {
-		return fmt.Errorf("team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token")
+		return fmt.Errorf("team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token, you can safely remove it from your configuration now")
 	}
 	return nil
 }

--- a/internal/provider/team_name_test.go
+++ b/internal/provider/team_name_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestTeamNameCannotBeChangedAfterCreate verifies team_name handling after a resource exists:
+// clearing it is a silent no-op (no plan change), while changing it to a different, non-empty
+// value fails with a helpful error. team_name is only used when creating a resource with a
+// global token.
+func TestTeamNameCannotBeChangedAfterCreate(t *testing.T) {
+	var data atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		prefix := "/api/v1/source-groups"
+		id := "1"
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == prefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data.Store(body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, body)))
+		case r.Method == http.MethodGet && r.RequestURI == prefix+"/"+id:
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, data.Load().([]byte))))
+		case r.Method == http.MethodDelete && r.RequestURI == prefix+"/"+id:
+			w.WriteHeader(http.StatusNoContent)
+			data.Store([]byte(nil))
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	withTeamName := func(teamName string) string {
+		return fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_source_group" "this" {
+					name      = "Test Source Group"
+					team_name = "%s"
+				}
+				`, teamName)
+	}
+	withoutTeamName := `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_source_group" "this" {
+					name = "Test Source Group"
+				}
+				`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create in a team.
+			{
+				Config: withTeamName("First team"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_source_group.this", "team_name", "First team"),
+				),
+			},
+			// Step 2 - clearing team_name is a no-op: no plan change, no error.
+			{
+				Config:   withoutTeamName,
+				PlanOnly: true,
+			},
+			// Step 3 - changing team_name to a different team must fail.
+			{
+				Config:      withTeamName("Second team"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`team_name cannot be changed after resource is created`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem

`team_name` is only used to pick the team when a resource is **created** with a global API token. Afterwards it is ignored, but a `DiffSuppressFunc` suppressed any diff on it once the resource existed — so changing `team_name` on an existing resource produced `No changes` with no explanation. Users had no way to tell the attribute was being silently ignored.

## Fix

- Replace the per-resource `DiffSuppressFunc` on `team_name` with a single shared `validateTeamNameNotChanged` `CustomizeDiff` that returns a clear error when `team_name` is changed to a non-empty value after the resource was created:

  > team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token

  Removing `team_name` after creation stays a silent no-op (it has no effect either way).
- Define the attribute through a shared `teamNameSchema()` helper so every resource is consistent, and add "You can't update this value later." to its description.
- Regenerate docs with `make gen`.

Applied consistently to every resource that supports the create-only `team_name`.

## Test

Adds `TestTeamNameCannotBeChangedAfterCreate`: creates a resource with a `team_name`, then asserts that changing it to a different value fails the plan with the new error.

Same as https://github.com/BetterStackHQ/terraform-provider-better-uptime/pull/207