### PR TITLE
[chore] Register cloudflare_prometheus_exporter platform

### DIFF
--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -44,6 +44,7 @@ When importing an existing source, leave `data_region` unset in your configurati
     - `azure`
     - `azure_logs`
     - `cloudflare_logpush`
+    - `cloudflare_prometheus_exporter`
     - `cloudflare_worker`
     - `datadog_agent`
     - `digitalocean`

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -28,6 +28,7 @@ This resource allows you to create, modify, and delete your Sources. For more in
     - `azure`
     - `azure_logs`
     - `cloudflare_logpush`
+    - `cloudflare_prometheus_exporter`
     - `cloudflare_worker`
     - `datadog_agent`
     - `digitalocean`

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -23,6 +23,7 @@ var platformTypes = []string{
 	"azure",
 	"azure_logs",
 	"cloudflare_logpush",
+	"cloudflare_prometheus_exporter",
 	"cloudflare_worker",
 	"datadog_agent",
 	"digitalocean",


### PR DESCRIPTION
## What

Registers the new **`cloudflare_prometheus_exporter`** telemetry source platform (title "Cloudflare exporter") in the Terraform provider.

We just split the Cloudflare exporter into its own source platform in the telemetry app ([logtail#14698](https://github.com/betterstackhq/logtail/pull/14698), merged). The public `logtail_source` API now accepts `platform = "cloudflare_prometheus_exporter"`, so the provider's valid-platform list needs it too — otherwise Terraform rejects the value client-side.

## Changes

- `internal/provider/resource_source.go` — add `cloudflare_prometheus_exporter` to `platformTypes` (alphabetically between `cloudflare_logpush` and `cloudflare_worker`). This drives both the `OneOf` validation and the generated docs.
- `docs/resources/source.md` + `docs/data-sources/source.md` — regenerated "Valid values" list (the description is built from `strings.Join(platformTypes, …)`).

Mirrors exactly how `cloudflare_logpush` / `prometheus_scrape` are wired. It's a scrape platform, so it reuses the existing `scrape_*` attributes (urls, frequency, headers, basic auth) with no new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)