### PR TITLE
Fable: Add merge logs and buffering settings to logtail_collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.14.0
+VERSION := 10.14.2
 .PHONY: test build
 
 help:

--- a/docs/data-sources/collector.md
+++ b/docs/data-sources/collector.md
@@ -59,15 +59,19 @@ When importing an existing collector, leave `data_region` unset in your configur
 
 Read-Only:
 
+- `buffer_max_events` (Number)
 - `components` (List of Object) (see [below for nested schema](#nestedobjatt--configuration--components))
 - `disk_batch_size_mb` (Number)
 - `log_line_length_limit_kb` (Number)
 - `logs_sample_rate` (Number)
 - `memory_batch_size_mb` (Number)
+- `merge_logs` (Boolean)
+- `merge_logs_config` (String)
 - `namespace_option` (Set of Object) (see [below for nested schema](#nestedobjatt--configuration--namespace_option))
 - `service_option` (Set of Object) (see [below for nested schema](#nestedobjatt--configuration--service_option))
 - `traces_sample_rate` (Number)
 - `vrl_transformation` (String)
+- `when_full` (String)
 
 <a id="nestedobjatt--configuration--components"></a>
 ### Nested Schema for `configuration.components`

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -39,6 +39,14 @@ resource "logtail_collector" "production" {
       logs_docker  = true
       ebpf_metrics = true
     }
+
+    # Merge multi-line logs (e.g. stack traces); a new entry starts when a line matches the VRL condition
+    merge_logs        = true
+    merge_logs_config = "match(string!(.message), r'^\\d{4}-\\d{2}-\\d{2}')"
+
+    # Overflow to disk after 50k in-memory events; block producers when the disk buffer is full
+    buffer_max_events = 50000
+    when_full         = "block"
   }
 
   # Server-side VRL runs during ingestion on Better Stack
@@ -93,15 +101,19 @@ When importing an existing collector, leave `data_region` unset in your configur
 
 Optional:
 
+- `buffer_max_events` (Number) Maximum number of events held in the collector's in-memory buffer before overflowing to the disk buffer. Defaults to 10000.
 - `components` (Block List, Max: 1) Enable or disable specific collector components. Maps to the Logs, Metrics, and eBPF tabs in the collector settings UI. (see [below for nested schema](#nestedblock--configuration--components))
 - `disk_batch_size_mb` (Number) Disk buffer size in MB for outgoing requests. Minimum 256 MB.
 - `log_line_length_limit_kb` (Number) Maximum log line length in kB. Lines longer than this are dropped by the collector to protect Vector from memory exhaustion. Higher values may use more memory. Must be between 4 and 128. Defaults to 8.
 - `logs_sample_rate` (Number) Sample rate for logs (0-100).
 - `memory_batch_size_mb` (Number) Memory batch size in MB for outgoing requests. Maximum 40 MB.
+- `merge_logs` (Boolean) Whether to merge multi-line logs (e.g. stack traces) into single log entries on the collector host before transmission. Matches the Merge logs tab in the collector's Transform data UI.
+- `merge_logs_config` (String) VRL condition detecting the first line of a new log entry — consecutive lines not matching it are merged into the preceding entry. Leave unset to use the built-in heuristic (lines starting with a timestamp or log level). Only used when `merge_logs` is `true`.
 - `namespace_option` (Block Set) Per-namespace overrides for log sampling rate and trace ingestion (Kubernetes only). Order-independent; entries are identified by name. (see [below for nested schema](#nestedblock--configuration--namespace_option))
 - `service_option` (Block Set) Per-service overrides for log sampling rate and trace ingestion. Only includes user-managed services; internal collector services (`better-stack-beyla`, `better-stack-collector`) are excluded. Use the `logtail_collector` data source to see all discovered services. (see [below for nested schema](#nestedblock--configuration--service_option))
 - `traces_sample_rate` (Number) Sample rate for traces (0-100).
 - `vrl_transformation` (String) VRL transformation that runs on the collector host, inside your infrastructure, before data is transmitted to Better Stack. Use this for PII redaction and sensitive data filtering — raw data never leaves your network. For server-side transformations that run during ingestion on Better Stack, use the top-level `source_vrl_transformation` attribute instead. Read more about [VRL transformations](https://betterstack.com/docs/logs/using-logtail/transforming-ingested-data/logs-vrl/).
+- `when_full` (String) What the collector does when the disk buffer is full. `drop_newest` (default) drops incoming data, preferring availability; `block` applies backpressure to producers, preferring completeness.
 
 <a id="nestedblock--configuration--components"></a>
 ### Nested Schema for `configuration.components`

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -33,6 +33,10 @@ resource "logtail_collector" "kubernetes_full" {
 
     log_line_length_limit_kb = 32
 
+    # Overflow to disk after 50k in-memory events; block producers when the disk buffer is full
+    buffer_max_events = 50000
+    when_full         = "block"
+
     components {
       ebpf_metrics      = true
       metrics_databases = true
@@ -95,6 +99,10 @@ resource "logtail_collector" "with_transformation" {
 
   # On-host VRL: PII never leaves your network
   configuration {
+    # Merge multi-line logs (e.g. stack traces); a new entry starts when a line matches the VRL condition
+    merge_logs        = true
+    merge_logs_config = "match(string!(.message), r'^\\d{4}-\\d{2}-\\d{2}')"
+
     vrl_transformation = <<-EOT
       # Redact e-mail addresses
       if is_string(.message) {

--- a/examples/collector/versions.tf
+++ b/examples/collector/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 10.12.2"
+      version = ">= 10.14.2"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/resources/logtail_collector/resource.tf
+++ b/examples/resources/logtail_collector/resource.tf
@@ -24,6 +24,14 @@ resource "logtail_collector" "production" {
       logs_docker  = true
       ebpf_metrics = true
     }
+
+    # Merge multi-line logs (e.g. stack traces); a new entry starts when a line matches the VRL condition
+    merge_logs        = true
+    merge_logs_config = "match(string!(.message), r'^\\d{4}-\\d{2}-\\d{2}')"
+
+    # Overflow to disk after 50k in-memory events; block producers when the disk buffer is full
+    buffer_max_events = 50000
+    when_full         = "block"
   }
 
   # Server-side VRL runs during ingestion on Better Stack

--- a/internal/provider/resource_collector.go
+++ b/internal/provider/resource_collector.go
@@ -266,6 +266,18 @@ var collectorSchema = map[string]*schema.Schema{
 						return normalizeVRL(old) == normalizeVRL(new)
 					},
 				},
+				"merge_logs": {
+					Description: "Whether to merge multi-line logs (e.g. stack traces) into single log entries on the collector host before transmission. Matches the Merge logs tab in the collector's Transform data UI.",
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Computed:    true,
+				},
+				"merge_logs_config": {
+					Description: "VRL condition detecting the first line of a new log entry — consecutive lines not matching it are merged into the preceding entry. Leave unset to use the built-in heuristic (lines starting with a timestamp or log level). Only used when `merge_logs` is `true`.",
+					Type:        schema.TypeString,
+					Optional:    true,
+					Computed:    true,
+				},
 				"disk_batch_size_mb": {
 					Description:  "Disk buffer size in MB for outgoing requests. Minimum 256 MB.",
 					Type:         schema.TypeInt,
@@ -279,6 +291,20 @@ var collectorSchema = map[string]*schema.Schema{
 					Optional:     true,
 					Computed:     true,
 					ValidateFunc: validation.IntAtMost(40),
+				},
+				"buffer_max_events": {
+					Description:  "Maximum number of events held in the collector's in-memory buffer before overflowing to the disk buffer. Defaults to 10000.",
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"when_full": {
+					Description:  "What the collector does when the disk buffer is full. `drop_newest` (default) drops incoming data, preferring availability; `block` applies backpressure to producers, preferring completeness.",
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringInSlice([]string{"drop_newest", "block"}, false),
 				},
 				"log_line_length_limit_kb": {
 					Description:  "Maximum log line length in kB. Lines longer than this are dropped by the collector to protect Vector from memory exhaustion. Higher values may use more memory. Must be between 4 and 128. Defaults to 8.",
@@ -379,8 +405,12 @@ type collectorConfiguration struct {
 	TracesSampleRate     *int                             `json:"traces_sample_rate,omitempty"`
 	Components           *collectorComponents             `json:"components,omitempty"`
 	VRLTransformation    *string                          `json:"vrl_transformation,omitempty"`
+	MergeLogs            *bool                            `json:"merge_logs,omitempty"`
+	MergeLogsConfig      *string                          `json:"merge_logs_config,omitempty"`
 	DiskBatchSizeMB      *int                             `json:"disk_batch_size_mb,omitempty"`
 	MemoryBatchSizeMB    *int                             `json:"memory_batch_size_mb,omitempty"`
+	BufferMaxEvents      *int                             `json:"buffer_max_events,omitempty"`
+	WhenFull             *string                          `json:"when_full,omitempty"`
 	LogLineLengthLimitKB *int                             `json:"log_line_length_limit_kb,omitempty"`
 	ServicesOptions      map[string]collectorEntityOption `json:"services_options,omitempty"`
 	NamespacesOptions    map[string]collectorEntityOption `json:"namespaces_options,omitempty"`
@@ -681,12 +711,16 @@ func loadCollectorConfiguration(d *schema.ResourceData) *collectorConfiguration 
 	if v, ok := configMap["vrl_transformation"].(string); ok && v != "" {
 		cfg.VRLTransformation = stringPtr(v)
 	}
+	cfg.MergeLogs = boolPtrIfSet(configMap, "merge_logs")
+	cfg.MergeLogsConfig = stringPtrIfSet(configMap, "merge_logs_config")
 	if v, ok := configMap["disk_batch_size_mb"].(int); ok && v != 0 {
 		cfg.DiskBatchSizeMB = intPtr(v)
 	}
 	if v, ok := configMap["memory_batch_size_mb"].(int); ok && v != 0 {
 		cfg.MemoryBatchSizeMB = intPtr(v)
 	}
+	cfg.BufferMaxEvents = intPtrIfSet(configMap, "buffer_max_events")
+	cfg.WhenFull = stringPtrIfSet(configMap, "when_full")
 	if v, ok := configMap["log_line_length_limit_kb"].(int); ok && v != 0 {
 		cfg.LogLineLengthLimitKB = intPtr(v)
 	}
@@ -975,11 +1009,23 @@ func collectorCopyAttrs(d *schema.ResourceData, in *collector) diag.Diagnostics 
 		if in.Configuration.VRLTransformation != nil {
 			configData["vrl_transformation"] = *in.Configuration.VRLTransformation
 		}
+		if in.Configuration.MergeLogs != nil {
+			configData["merge_logs"] = *in.Configuration.MergeLogs
+		}
+		if in.Configuration.MergeLogsConfig != nil {
+			configData["merge_logs_config"] = *in.Configuration.MergeLogsConfig
+		}
 		if in.Configuration.DiskBatchSizeMB != nil {
 			configData["disk_batch_size_mb"] = *in.Configuration.DiskBatchSizeMB
 		}
 		if in.Configuration.MemoryBatchSizeMB != nil {
 			configData["memory_batch_size_mb"] = *in.Configuration.MemoryBatchSizeMB
+		}
+		if in.Configuration.BufferMaxEvents != nil {
+			configData["buffer_max_events"] = *in.Configuration.BufferMaxEvents
+		}
+		if in.Configuration.WhenFull != nil {
+			configData["when_full"] = *in.Configuration.WhenFull
 		}
 		if in.Configuration.LogLineLengthLimitKB != nil {
 			configData["log_line_length_limit_kb"] = *in.Configuration.LogLineLengthLimitKB

--- a/internal/provider/resource_collector_test.go
+++ b/internal/provider/resource_collector_test.go
@@ -1088,6 +1088,181 @@ func TestResourceCollectorNewFeatures(t *testing.T) {
 		},
 	})
 
+	// Test merge multi-line logs
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create with merge logs enabled and a custom starts-when condition
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						merge_logs        = true
+						merge_logs_config = "match(string!(.message), r'^\\d{4}-\\d{2}-\\d{2}')"
+					}
+				}
+				`, name, platform),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("logtail_collector.this", "id"),
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.merge_logs", "true"),
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.merge_logs_config", "match(string!(.message), r'^\\d{4}-\\d{2}-\\d{2}')"),
+				),
+			},
+			// Step 2 - update the condition
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						merge_logs        = true
+						merge_logs_config = "match(string!(.message), r'^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)')"
+					}
+				}
+				`, name, platform),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.merge_logs", "true"),
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.merge_logs_config", "match(string!(.message), r'^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)')"),
+				),
+			},
+			// Step 3 - disable merging; the condition stays in state for re-enabling
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						merge_logs        = false
+						merge_logs_config = "match(string!(.message), r'^(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)')"
+					}
+				}
+				`, name, platform),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.merge_logs", "false"),
+				),
+			},
+		},
+	})
+
+	// Test buffering settings (buffer_max_events, when_full)
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create with buffering settings
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						buffer_max_events = 50000
+						when_full         = "block"
+					}
+				}
+				`, name, platform),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("logtail_collector.this", "id"),
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.buffer_max_events", "50000"),
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.when_full", "block"),
+				),
+			},
+			// Step 2 - update buffering settings
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						buffer_max_events = 25000
+						when_full         = "drop_newest"
+					}
+				}
+				`, name, platform),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.buffer_max_events", "25000"),
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.when_full", "drop_newest"),
+				),
+			},
+			// Step 3 - invalid when_full is rejected at plan time
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						when_full = "explode"
+					}
+				}
+				`, name, platform),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected configuration\.0\.when_full to be one of`),
+			},
+			// Step 4 - back to a valid config so the post-test destroy plan validates
+			{
+				Config: fmt.Sprintf(`
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector" "this" {
+					name     = "%s"
+					platform = "%s"
+
+					configuration {
+						buffer_max_events = 25000
+						when_full         = "drop_newest"
+					}
+				}
+				`, name, platform),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_collector.this", "configuration.0.when_full", "drop_newest"),
+				),
+			},
+		},
+	})
+
 	// Test log_line_length_limit_kb
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,


### PR DESCRIPTION
## Why

The collector API supports merge multi-line logs and buffering settings.

## What

Four new attributes in the `configuration` block (resource + data source, which derives its schema automatically):

- `merge_logs` (Bool) — merge multi-line logs (e.g. stack traces) into single entries on the collector host.
- `merge_logs_config` (String) — VRL "starts when" condition detecting the first line of a new entry; unset falls back to the server-side default heuristic (timestamp / log-level prefixes). Stored verbatim by the API, so no `normalizeVRL` diff-suppression.
- `buffer_max_events` (Int, `≥ 1`) — in-memory buffer capacity before overflowing to the disk buffer; server default 10000.
- `when_full` (String, `drop_newest` | `block`) — disk-buffer overflow strategy, validated at plan time mirroring the API's `VALID_WHEN_FULL_VALUES`.

All Optional+Computed, following the existing `components` convention: updates send the effective state value, so UI-managed settings are not clobbered by Terraform runs that don't manage them.

Example (`examples/resources/logtail_collector/resource.tf`) extended; docs regenerated via `make gen`.