### PR TITLE
Add pgbouncer kind to logtail_collector_target

### DIFF
--- a/docs/resources/collector_target.md
+++ b/docs/resources/collector_target.md
@@ -3,12 +3,12 @@
 page_title: "logtail_collector_target Resource - terraform-provider-logtail"
 subcategory: ""
 description: |-
-  Manages a single 'Collect metrics' target on a Better Stack Collector — a database (postgres, mysql, redis, mongodb, memcached, elasticsearch) or process exporter (nginx, apache, kafka, prometheus) that the collector scrapes.
+  Manages a single 'Collect metrics' target on a Better Stack Collector — a database (postgres, pgbouncer, mysql, redis, mongodb, memcached, elasticsearch) or process exporter (nginx, apache, kafka, prometheus) that the collector scrapes.
 ---
 
 # logtail_collector_target (Resource)
 
-Manages a single 'Collect metrics' target on a Better Stack Collector — a database (postgres, mysql, redis, mongodb, memcached, elasticsearch) or process exporter (nginx, apache, kafka, prometheus) that the collector scrapes.
+Manages a single 'Collect metrics' target on a Better Stack Collector — a database (postgres, pgbouncer, mysql, redis, mongodb, memcached, elasticsearch) or process exporter (nginx, apache, kafka, prometheus) that the collector scrapes.
 
 ## Example Usage
 
@@ -22,6 +22,17 @@ resource "logtail_collector_target" "primary_db" {
   username     = "monitor"
   password     = var.pg_monitor_password
   ssl_mode     = "require"
+}
+
+# Database target — PgBouncer pooler in front of PostgreSQL.
+resource "logtail_collector_target" "pooler" {
+  collector_id = logtail_collector.production.id
+  kind         = "pgbouncer"
+  host         = "10.0.0.5"
+  port         = 6432
+  username     = "monitor"
+  password     = var.pgbouncer_monitor_password
+  ssl_mode     = "disable"
 }
 
 # Database target — Elasticsearch with API key authentication.
@@ -72,7 +83,7 @@ resource "logtail_collector_target" "paused_replica" {
 ### Required
 
 - `collector_id` (String) The ID of the collector this target belongs to.
-- `kind` (String) The target kind. One of: postgres, mysql, redis, mongodb, memcached, elasticsearch, nginx, apache, kafka, prometheus.
+- `kind` (String) The target kind. One of: postgres, pgbouncer, mysql, redis, mongodb, memcached, elasticsearch, nginx, apache, kafka, prometheus.
 
 ### Optional
 
@@ -80,7 +91,7 @@ resource "logtail_collector_target" "paused_replica" {
 - `collector_host` (String) Hostname of the collector host running this process. Use this for process kinds (nginx, apache, kafka, prometheus). Must match the hostname of a `collector_host` reporting to this collector. For database kinds use `host` instead.
 - `enabled` (Boolean) Whether the collector should scrape this target. Defaults to `true` server-side. Setting to `false` puts the target into `disabled` status — it remains configured but is not scraped.
 - `endpoint` (String) Full scrape URL. Required for prometheus.
-- `host` (String) Hostname or IP of the database server. Use this for database kinds (postgres, mysql, redis, mongodb, memcached, elasticsearch). For process kinds use `collector_host` instead.
+- `host` (String) Hostname or IP of the database server. Use this for database kinds (postgres, pgbouncer, mysql, redis, mongodb, memcached, elasticsearch). For process kinds use `collector_host` instead.
 - `listen_ip` (String) IP address the process listens on, as seen from the collector host. Used for nginx, apache, kafka.
 - `password` (String, Sensitive) Password for authentication. Used by database kinds.
 - `port` (Number) Port the target listens on. Required for database kinds and most process kinds; not used by prometheus (use `endpoint` instead).

--- a/examples/resources/logtail_collector_target/resource.tf
+++ b/examples/resources/logtail_collector_target/resource.tf
@@ -9,6 +9,17 @@ resource "logtail_collector_target" "primary_db" {
   ssl_mode     = "require"
 }
 
+# Database target — PgBouncer pooler in front of PostgreSQL.
+resource "logtail_collector_target" "pooler" {
+  collector_id = logtail_collector.production.id
+  kind         = "pgbouncer"
+  host         = "10.0.0.5"
+  port         = 6432
+  username     = "monitor"
+  password     = var.pgbouncer_monitor_password
+  ssl_mode     = "disable"
+}
+
 # Database target — Elasticsearch with API key authentication.
 resource "logtail_collector_target" "search" {
   collector_id = logtail_collector.production.id

--- a/internal/provider/resource_collector_target.go
+++ b/internal/provider/resource_collector_target.go
@@ -13,7 +13,7 @@ import (
 )
 
 var collectorTargetKinds = []string{
-	"postgres", "mysql", "redis", "mongodb", "memcached", "elasticsearch",
+	"postgres", "pgbouncer", "mysql", "redis", "mongodb", "memcached", "elasticsearch",
 	"nginx", "apache", "kafka", "prometheus",
 }
 
@@ -28,6 +28,7 @@ var collectorTargetProcessKinds = map[string]bool{
 // Lets plan-time validation reject fields that would no-op or 422 on apply.
 var collectorTargetAllowedFields = map[string]map[string]bool{
 	"postgres":      {"host": true, "port": true, "username": true, "password": true, "ssl_mode": true},
+	"pgbouncer":     {"host": true, "port": true, "username": true, "password": true, "ssl_mode": true},
 	"mysql":         {"host": true, "port": true, "username": true, "password": true, "tls": true},
 	"redis":         {"host": true, "port": true, "username": true, "password": true},
 	"mongodb":       {"host": true, "port": true, "username": true, "password": true},
@@ -66,7 +67,7 @@ var collectorTargetSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice(collectorTargetKinds, false),
 	},
 	"host": {
-		Description: "Hostname or IP of the database server. Use this for database kinds (postgres, mysql, redis, mongodb, memcached, elasticsearch). For process kinds use `collector_host` instead.",
+		Description: "Hostname or IP of the database server. Use this for database kinds (postgres, pgbouncer, mysql, redis, mongodb, memcached, elasticsearch). For process kinds use `collector_host` instead.",
 		Type:        schema.TypeString,
 		Optional:    true,
 	},
@@ -195,7 +196,7 @@ func newCollectorTargetResource() *schema.Resource {
 			StateContext: collectorTargetImport,
 		},
 		CustomizeDiff: validateCollectorTarget,
-		Description:   "Manages a single 'Collect metrics' target on a Better Stack Collector — a database (postgres, mysql, redis, mongodb, memcached, elasticsearch) or process exporter (nginx, apache, kafka, prometheus) that the collector scrapes.",
+		Description:   "Manages a single 'Collect metrics' target on a Better Stack Collector — a database (postgres, pgbouncer, mysql, redis, mongodb, memcached, elasticsearch) or process exporter (nginx, apache, kafka, prometheus) that the collector scrapes.",
 		Schema:        collectorTargetSchema,
 	}
 }
@@ -239,7 +240,7 @@ func validateCollectorTarget(ctx context.Context, diff *schema.ResourceDiff, v i
 		}
 		// Mirror the API's per-kind required fields (telemetry: CollectorTarget#validate_settings_for_kind)
 		// so a missing ssl_mode/tls is caught at plan time instead of as a 422 on apply.
-		if kind == "postgres" && diff.Get("ssl_mode").(string) == "" {
+		if (kind == "postgres" || kind == "pgbouncer") && diff.Get("ssl_mode").(string) == "" {
 			return fmt.Errorf("ssl_mode is required for kind %q", kind)
 		}
 		if kind == "mysql" && diff.Get("tls").(string) == "" {

--- a/internal/provider/resource_collector_target_test.go
+++ b/internal/provider/resource_collector_target_test.go
@@ -229,6 +229,46 @@ func TestResourceCollectorTargetElasticsearch(t *testing.T) {
 	})
 }
 
+func TestResourceCollectorTargetPgbouncer(t *testing.T) {
+	server, _ := newCollectorTargetMockServer(t, "77", "8")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_collector_target" "pooler" {
+					collector_id = "77"
+					kind         = "pgbouncer"
+					host         = "pooler.example.com"
+					port         = 6432
+					username     = "monitor"
+					password     = "secret"
+					ssl_mode     = "disable"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_collector_target.pooler", "kind", "pgbouncer"),
+					resource.TestCheckResourceAttr("logtail_collector_target.pooler", "port", "6432"),
+					resource.TestCheckResourceAttr("logtail_collector_target.pooler", "ssl_mode", "disable"),
+					// Password preserved from config across the API round-trip (API does not return it).
+					resource.TestCheckResourceAttr("logtail_collector_target.pooler", "password", "secret"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceCollectorTargetProcess(t *testing.T) {
 	server, _ := newCollectorTargetMockServer(t, "77", "9")
 	defer server.Close()
@@ -491,6 +531,32 @@ func TestResourceCollectorTargetValidation(t *testing.T) {
 			}
 			`,
 			errorRe: `ssl_mode is required for kind "postgres"`,
+		},
+		{
+			name: "pgbouncer without ssl_mode",
+			config: `
+			resource "logtail_collector_target" "x" {
+				collector_id = "1"
+				kind         = "pgbouncer"
+				host         = "pooler.example.com"
+				port         = 6432
+			}
+			`,
+			errorRe: `ssl_mode is required for kind "pgbouncer"`,
+		},
+		{
+			name: "pgbouncer with mysql tls (not allowed)",
+			config: `
+			resource "logtail_collector_target" "x" {
+				collector_id = "1"
+				kind         = "pgbouncer"
+				host         = "pooler.example.com"
+				port         = 6432
+				ssl_mode     = "disable"
+				tls          = "true"
+			}
+			`,
+			errorRe: `tls is not valid for kind "pgbouncer"`,
 		},
 		{
 			name: "mysql without tls",


### PR DESCRIPTION
The collector targets API now accepts `pgbouncer` targets, taking the same fields as `postgres` (`host`, `port`, `username`, `password`, `ssl_mode`). This mirrors it in the provider:

- `kind` accepts `pgbouncer` (listed right after `postgres`, matching the API)
- per-kind field whitelist entry, so forbidden fields (e.g. `tls`) are rejected at plan time
- `ssl_mode` is required for `pgbouncer` at plan time, mirroring the server-side validation
- regenerated docs (`make gen`) + PgBouncer example

Tests: `TestResourceCollectorTargetPgbouncer` (create round-trip via mock server), validation cases for missing `ssl_mode` and forbidden `tls`; full `go test ./...` green, `make lint` clean.