### PR TITLE
Make logtail_metric.aggregations optional and align valid values with the API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.14.2
+VERSION := 10.14.3
 .PHONY: test build
 
 help:

--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -22,7 +22,7 @@ This Data Source allows you to look up existing Metrics using their name. You ca
 
 ### Read-Only
 
-- `aggregations` (List of String) The list of aggregations to perform on the metric.
+- `aggregations` (List of String) The list of aggregations to perform on the metric. Optional: omit it (or set it to an empty list) to create a Label (a group-by dimension) instead of a Metric.
 - `id` (String) The ID of this metric.
 - `sql_expression` (String) The SQL expression used to extract the metric value.
 - `type` (String) The type of the metric.

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -17,11 +17,14 @@ This resource allows you to create, update and delete Metrics.
 
 ### Required
 
-- `aggregations` (List of String) The list of aggregations to perform on the metric.
 - `name` (String) The name of this metric.
 - `source_id` (String) The ID of the source this metric belongs to.
 - `sql_expression` (String) The SQL expression used to extract the metric value.
 - `type` (String) The type of the metric.
+
+### Optional
+
+- `aggregations` (List of String) The list of aggregations to perform on the metric. Optional: omit it (or set it to an empty list) to create a Label (a group-by dimension) instead of a Metric.
 
 ### Read-Only
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -41,7 +41,7 @@ resource "logtail_metric" "duration_ms" {
   source_id      = logtail_source.this.id
   name           = "duration_ms"
   sql_expression = "getJSON(raw, 'duration_ms')"
-  aggregations   = ["avg", "max", "min"]
+  aggregations   = ["avg", "max", "min", "histogram"]
   type           = "float64_delta"
 }
 
@@ -50,6 +50,15 @@ resource "logtail_metric" "service_name" {
   name           = "service_name"
   sql_expression = "getJSON(raw, 'service_name')"
   aggregations   = []
+  type           = "string_low_cardinality"
+}
+
+# aggregations is optional — omitting it creates a Label (a group-by dimension)
+# rather than a Metric.
+resource "logtail_metric" "service_version" {
+  source_id      = logtail_source.this.id
+  name           = "service_version"
+  sql_expression = "getJSON(raw, 'service_version')"
   type           = "string_low_cardinality"
 }
 

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 10.14.0"
+      version = ">= 10.14.3"
     }
   }
 }

--- a/internal/provider/resource_metric.go
+++ b/internal/provider/resource_metric.go
@@ -38,10 +38,10 @@ var metricSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"aggregations": {
-		Description: "The list of aggregations to perform on the metric.",
+		Description: "The list of aggregations to perform on the metric. Optional: omit it (or set it to an empty list) to create a Label (a group-by dimension) instead of a Metric.",
 		Type:        schema.TypeList,
-		Required:    true,
-		Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validation.StringInSlice([]string{"avg", "count", "uniq", "max", "min", "anyLast", "sum", "p50", "p90", "p95", "p99"}, false)},
+		Optional:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString, ValidateFunc: validation.StringInSlice([]string{"avg", "count", "uniq", "max", "min", "sum", "histogram"}, false)},
 	},
 	"type": {
 		Description:  "The type of the metric.",
@@ -108,11 +108,28 @@ func metricRef(in *metric) []struct {
 	}
 }
 
+// aggregations is optional. An empty list means this expression is a Label (a
+// group-by dimension) rather than a Metric. We always send the field — even when
+// empty — so that omitting it creates a Label, and clearing it on an existing
+// Metric converts it into a Label in place, instead of the field being omitted
+// from the request and the previous aggregations left untouched.
+func ensureAggregations(in *metric) {
+	// load() leaves Aggregations as a nil pointer when the field is omitted, and as
+	// a pointer to a nil slice when it is set to an empty list — both of which would
+	// marshal to a missing field or `null`. Normalise both to an empty slice so the
+	// request always carries `"aggregations": []`.
+	if in.Aggregations == nil || *in.Aggregations == nil {
+		empty := []string{}
+		in.Aggregations = &empty
+	}
+}
+
 func metricCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in metric
 	for _, e := range metricRef(&in) {
 		load(d, e.k, e.v)
 	}
+	ensureAggregations(&in)
 	sourceId := d.Get("source_id").(string)
 	var out metricHTTPResponse
 	if err := resourceCreate(ctx, meta, fmt.Sprintf("/api/v2/sources/%s/metrics", url.PathEscape(sourceId)), &in, &out); err != nil {
@@ -185,6 +202,7 @@ func metricUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	for _, e := range metricRef(&in) {
 		load(d, e.k, e.v)
 	}
+	ensureAggregations(&in)
 	sourceId := d.Get("source_id").(string)
 	if diags := resourceUpdate(ctx, meta, fmt.Sprintf("/api/v2/sources/%s/metrics/%s", url.PathEscape(sourceId), url.PathEscape(d.Id())), &in); diags != nil {
 		return diags

--- a/internal/provider/resource_metric_label_test.go
+++ b/internal/provider/resource_metric_label_test.go
@@ -1,0 +1,169 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestResourceMetricAsLabel covers issue #79: aggregations is optional, so a
+// metric expression with no aggregations is a Label rather than a Metric. It
+// also exercises converting a Label into a Metric and back, asserting that the
+// request body always carries the aggregations field (empty for a Label) so the
+// backend can switch kinds in place instead of leaving the old value untouched.
+func TestResourceMetricAsLabel(t *testing.T) {
+	var data atomic.Value
+	var id atomic.Value
+	var lastPostBody atomic.Value
+	var lastPatchBody atomic.Value
+	id.Store(0)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		prefix := "/api/v2/sources/source123/metrics"
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == prefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lastPostBody.Store(body)
+			data.Store(body)
+			w.WriteHeader(http.StatusCreated)
+			id.Store(id.Load().(int) + 1)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"%d","attributes":%s}}`, id.Load(), body)))
+		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=1":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"%d","attributes":%s}],"pagination":{"next":null}}`, id.Load(), data.Load())))
+		case r.Method == http.MethodPatch && r.RequestURI == fmt.Sprintf(`%s/%d`, prefix, id.Load()):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lastPatchBody.Store(body)
+			data.Store(body)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"%d","attributes":%s}}`, id.Load(), body)))
+		case r.Method == http.MethodDelete && r.RequestURI == fmt.Sprintf(`%s/%d`, prefix, id.Load()):
+			w.WriteHeader(http.StatusNoContent)
+			data.Store([]byte(nil))
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	// aggregationsInBody returns a check that decodes the most recent request body
+	// (POST or PATCH) and asserts the aggregations field equals want. A non-nil
+	// empty slice (a Label) is required — a missing/null field would let the
+	// backend keep the previous aggregations.
+	aggregationsInBody := func(store *atomic.Value, want []string) resource.TestCheckFunc {
+		return func(*terraform.State) error {
+			raw, _ := store.Load().([]byte)
+			var got metric
+			if err := json.Unmarshal(raw, &got); err != nil {
+				return fmt.Errorf("body not valid JSON: %v (body=%s)", err, string(raw))
+			}
+			if got.Aggregations == nil {
+				return fmt.Errorf("body missing `aggregations` field (body=%s)", string(raw))
+			}
+			if fmt.Sprint(*got.Aggregations) != fmt.Sprint(want) {
+				return fmt.Errorf("body aggregations = %v, want %v (body=%s)", *got.Aggregations, want, string(raw))
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create a Label by omitting aggregations entirely.
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+				resource "logtail_metric" "this" {
+					source_id      = "source123"
+					name           = "service_name"
+					sql_expression = "getJSON(raw, 'service_name')"
+					type           = "string_low_cardinality"
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.#", "0"),
+					// The create request must still carry an (empty) aggregations list.
+					aggregationsInBody(&lastPostBody, []string{}),
+				),
+			},
+			// Step 2 - no changes, plan must be empty (no perpetual diff on the
+			// optional/empty list).
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+				resource "logtail_metric" "this" {
+					source_id      = "source123"
+					name           = "service_name"
+					sql_expression = "getJSON(raw, 'service_name')"
+					type           = "string_low_cardinality"
+				}`,
+				PlanOnly: true,
+			},
+			// Step 3 - convert the Label into a Metric by adding aggregations.
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+				resource "logtail_metric" "this" {
+					source_id      = "source123"
+					name           = "service_name"
+					sql_expression = "getJSON(raw, 'service_name')"
+					type           = "string_low_cardinality"
+					aggregations   = ["uniq"]
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.#", "1"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.0", "uniq"),
+					aggregationsInBody(&lastPatchBody, []string{"uniq"}),
+				),
+			},
+			// Step 4 - convert it back into a Label by clearing aggregations. The
+			// PATCH body must send an explicit empty list, not omit the field.
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+				resource "logtail_metric" "this" {
+					source_id      = "source123"
+					name           = "service_name"
+					sql_expression = "getJSON(raw, 'service_name')"
+					type           = "string_low_cardinality"
+					aggregations   = []
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.#", "0"),
+					aggregationsInBody(&lastPatchBody, []string{}),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_metric_test.go
+++ b/internal/provider/resource_metric_test.go
@@ -79,7 +79,7 @@ func TestResourceMetric(t *testing.T) {
 					name           = "%s"
 					sql_expression = "%s"
 					type           = "%s"
-					aggregations   = ["avg", "p50"]
+					aggregations   = ["avg", "histogram"]
 				}
 				`, sourceID, name, sqlExpression, metricType),
 				Check: resource.ComposeTestCheckFunc(
@@ -90,7 +90,7 @@ func TestResourceMetric(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_metric.this", "type", metricType),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.#", "2"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.0", "avg"),
-					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.1", "p50"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.1", "histogram"),
 				),
 				PreConfig: func() {
 					t.Log("step 1")
@@ -112,7 +112,7 @@ func TestResourceMetric(t *testing.T) {
 				}
 				`, sourceID, name, sqlExpression),
 				Check:       resource.ComposeTestCheckFunc(),
-				ExpectError: regexp.MustCompile(`expected type to be one of \["string_low_cardinality" "int64_delta" "float64_delta" "datetime64_delta" "boolean"], got mystery_column(.|\n)*expected aggregations\.2 to be one of \["avg" "count" "uniq" "max" "min" "anyLast" "sum" "p50" "p90" "p95" "p99"], got best`),
+				ExpectError: regexp.MustCompile(`expected type to be one of \["string_low_cardinality" "int64_delta" "float64_delta" "datetime64_delta" "boolean"], got mystery_column(.|\n)*expected aggregations\.2 to be one of \["avg" "count" "uniq" "max" "min" "sum" "histogram"], got best`),
 				PreConfig: func() {
 					t.Log("step 2")
 				},

--- a/internal/provider/resource_metric_update_test.go
+++ b/internal/provider/resource_metric_update_test.go
@@ -94,7 +94,7 @@ func TestResourceMetricUpdateMultipleFields(t *testing.T) {
 					name           = "Completely Different"
 					sql_expression = "JSONExtract(json, 'new', 'Float')"
 					type           = "float64_delta"
-					aggregations   = ["min", "max", "p99"]
+					aggregations   = ["min", "max", "histogram"]
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
@@ -104,7 +104,7 @@ func TestResourceMetricUpdateMultipleFields(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.#", "3"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.0", "min"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.1", "max"),
-					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.2", "p99"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.2", "histogram"),
 					func(*terraform.State) error {
 						if got := patchCount.Load(); got != 1 {
 							return fmt.Errorf("expected exactly 1 PATCH in this step, got %d", got)
@@ -118,7 +118,7 @@ func TestResourceMetricUpdateMultipleFields(t *testing.T) {
 							Name:          strPtr("Completely Different"),
 							SQLExpression: strPtr("JSONExtract(json, 'new', 'Float')"),
 							Type:          strPtr("float64_delta"),
-							Aggregations:  strSlicePtr("min", "max", "p99"),
+							Aggregations:  strSlicePtr("min", "max", "histogram"),
 						}
 						if !reflect.DeepEqual(got, want) {
 							return fmt.Errorf("PATCH body mismatch.\n got: %+v\nwant: %+v\nraw: %s", got, want, string(raw))
@@ -320,7 +320,7 @@ func TestResourceMetricPatchErrorPropagates(t *testing.T) {
 					name           = "M"
 					sql_expression = "JSONExtract(json, 'x', 'Float')"
 					type           = "float64_delta"
-					aggregations   = ["p95"]
+					aggregations   = ["sum"]
 				}`,
 				ExpectError: regexp.MustCompile(`PATCH .*?/metrics/1 returned 422.*boom`),
 			},


### PR DESCRIPTION
## Problem

Two inconsistencies between `logtail_metric` and the Telemetry Metrics API:

1. **`aggregations` is required in the provider but optional in the API** (#79). The [API](https://betterstack.com/docs/logs/api/creating-a-metric/) treats a metric expression with no `aggregations` as a **Label** (a group-by dimension) rather than a **Metric**. Because the provider marked `aggregations` as `Required`, Labels could only be created via raw API calls or the UI — not Terraform.

2. **The plan-time validation list for `aggregations` doesn't match the API** (#81). The provider accepted `anyLast`, `p50`, `p90`, `p95`, `p99` — which the API rejects at apply time with `422 aggregations must be one or more of avg, count, uniq, max, min, sum, histogram` — and rejected `histogram`, which the API accepts. So a config could pass `terraform plan` and then fail `apply`, or be blocked at plan time for a value the API actually allows.

## Fix

- Make `aggregations` **`Optional`**. Omit it (or set `aggregations = []`) to create a Label; add aggregations to an existing Label to turn it into a Metric, and clear them to turn it back.
- Always send an explicit `aggregations` array in the create/update request (empty for a Label). `load()` would otherwise omit the field or send `null`, so clearing aggregations on an existing Metric would be silently dropped, leaving it a Metric and producing a perpetual diff. Normalising to `[]` lets the backend switch a Metric into a Label in place.
- Replace the validation set with the one the API actually enforces: `avg, count, uniq, max, min, sum, histogram`.
- Regenerate `docs/resources/metric.md` and bump `VERSION` / the advanced example's `versions.tf` to `10.14.3`.
- Exercise the new behaviour in `examples/advanced`: a Label that omits `aggregations`, and a `histogram` aggregation on the `duration_ms` metric.

> The Telemetry API already supports all of this — creating Labels (no/empty aggregations) and converting between a Metric and a Label by changing `aggregations` — so this is purely a provider-side alignment. No API change is required.

## Test

- `TestResourceMetricAsLabel` (new): creates a Label by omitting `aggregations`, asserts an empty `aggregations` array is sent and the plan is stable, then converts Label → Metric → Label, asserting the request body carries the right `aggregations` each time (an explicit `[]` when clearing).
- Updated the existing metric tests to use API-valid aggregations (`histogram`/`sum` instead of `p50`/`p95`/`p99`) and the new validation-error message.

Resolves #79
Resolves #81