### PR TITLE
T-18887 Deprecate logtail_metric.type and stop sending it by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.0
+VERSION := 10.15.1
 .PHONY: test build
 
 help:

--- a/docs/data-sources/metric.md
+++ b/docs/data-sources/metric.md
@@ -25,4 +25,4 @@ This Data Source allows you to look up existing Metrics using their name. You ca
 - `aggregations` (List of String) The list of aggregations to perform on the metric. Optional: omit it (or set it to an empty list) to create a Label (a group-by dimension) instead of a Metric.
 - `id` (String) The ID of this metric.
 - `sql_expression` (String) The SQL expression used to extract the metric value.
-- `type` (String) The type of the metric.
+- `type` (String, Deprecated) The type of the metric.

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -3,12 +3,12 @@
 page_title: "logtail_metric Resource - terraform-provider-logtail"
 subcategory: ""
 description: |-
-  This resource allows you to create, update and delete Metrics.
+  This resource allows you to create, update and delete Metrics and Labels.
 ---
 
 # logtail_metric (Resource)
 
-This resource allows you to create, update and delete Metrics.
+This resource allows you to create, update and delete Metrics and Labels.
 
 
 
@@ -20,11 +20,11 @@ This resource allows you to create, update and delete Metrics.
 - `name` (String) The name of this metric.
 - `source_id` (String) The ID of the source this metric belongs to.
 - `sql_expression` (String) The SQL expression used to extract the metric value.
-- `type` (String) The type of the metric.
 
 ### Optional
 
 - `aggregations` (List of String) The list of aggregations to perform on the metric. Optional: omit it (or set it to an empty list) to create a Label (a group-by dimension) instead of a Metric.
+- `type` (String, Deprecated) The type of the metric.
 
 ### Read-Only
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -42,7 +42,6 @@ resource "logtail_metric" "duration_ms" {
   name           = "duration_ms"
   sql_expression = "getJSON(raw, 'duration_ms')"
   aggregations   = ["avg", "max", "min", "histogram"]
-  type           = "float64_delta"
 }
 
 resource "logtail_metric" "service_name" {
@@ -50,16 +49,13 @@ resource "logtail_metric" "service_name" {
   name           = "service_name"
   sql_expression = "getJSON(raw, 'service_name')"
   aggregations   = []
-  type           = "string_low_cardinality"
 }
 
-# aggregations is optional — omitting it creates a Label (a group-by dimension)
-# rather than a Metric.
+# aggregations field is optional — omitting it creates a Label (a group-by dimension) rather than a Metric.
 resource "logtail_metric" "service_version" {
   source_id      = logtail_source.this.id
   name           = "service_version"
   sql_expression = "getJSON(raw, 'service_version')"
-  type           = "string_low_cardinality"
 }
 
 data "logtail_metric" "level" {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 10.15.0"
+      version = ">= 10.15.1"
     }
   }
 }

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -173,6 +173,5 @@ resource "logtail_metric" "docker_error_rate" {
   source_id      = logtail_collector.docker_basic.source_id
   name           = "duration_ms"
   sql_expression = "getJSON(raw, 'duration_ms')"
-  type           = "float64_delta"
   aggregations   = ["avg", "max", "min"]
 }

--- a/internal/provider/resource_metric.go
+++ b/internal/provider/resource_metric.go
@@ -46,7 +46,9 @@ var metricSchema = map[string]*schema.Schema{
 	"type": {
 		Description:  "The type of the metric.",
 		Type:         schema.TypeString,
-		Required:     true,
+		Optional:     true,
+		Computed:     true,
+		Deprecated:   "This property is deprecated, and safe to omit. Labels are represented by strings and Metric values by floats.",
 		ValidateFunc: validation.StringInSlice([]string{"string_low_cardinality", "int64_delta", "float64_delta", "datetime64_delta", "boolean"}, false),
 	},
 }
@@ -60,7 +62,7 @@ func newMetricResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource allows you to create, update and delete Metrics.",
+		Description: "This resource allows you to create, update and delete Metrics and Labels.",
 		Schema:      metricSchema,
 	}
 }
@@ -108,6 +110,20 @@ func metricRef(in *metric) []struct {
 	}
 }
 
+// loadMetric populates in from d. `type` is deprecated and Computed, so reading it
+// via GetOkExists would echo the API-returned value back even after the user removed
+// it from config — sourcing it from rawConfig instead means we only send it when it
+// is actually set in the user's HCL.
+func loadMetric(d *schema.ResourceData, in *metric) {
+	for _, e := range metricRef(in) {
+		if e.k == "type" {
+			continue
+		}
+		load(d, e.k, e.v)
+	}
+	in.Type = stringFromResourceData(d, "type")
+}
+
 // aggregations is optional. An empty list means this expression is a Label (a
 // group-by dimension) rather than a Metric. We always send the field — even when
 // empty — so that omitting it creates a Label, and clearing it on an existing
@@ -126,9 +142,7 @@ func ensureAggregations(in *metric) {
 
 func metricCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in metric
-	for _, e := range metricRef(&in) {
-		load(d, e.k, e.v)
-	}
+	loadMetric(d, &in)
 	ensureAggregations(&in)
 	sourceId := d.Get("source_id").(string)
 	var out metricHTTPResponse
@@ -199,9 +213,7 @@ func metricCopyAttrs(d *schema.ResourceData, in *metric) diag.Diagnostics {
 
 func metricUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in metric
-	for _, e := range metricRef(&in) {
-		load(d, e.k, e.v)
-	}
+	loadMetric(d, &in)
 	ensureAggregations(&in)
 	sourceId := d.Get("source_id").(string)
 	if diags := resourceUpdate(ctx, meta, fmt.Sprintf("/api/v2/sources/%s/metrics/%s", url.PathEscape(sourceId), url.PathEscape(d.Id())), &in); diags != nil {

--- a/internal/provider/resource_metric_label_test.go
+++ b/internal/provider/resource_metric_label_test.go
@@ -100,7 +100,6 @@ func TestResourceMetricAsLabel(t *testing.T) {
 					source_id      = "source123"
 					name           = "service_name"
 					sql_expression = "getJSON(raw, 'service_name')"
-					type           = "string_low_cardinality"
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
@@ -120,7 +119,6 @@ func TestResourceMetricAsLabel(t *testing.T) {
 					source_id      = "source123"
 					name           = "service_name"
 					sql_expression = "getJSON(raw, 'service_name')"
-					type           = "string_low_cardinality"
 				}`,
 				PlanOnly: true,
 			},
@@ -134,7 +132,6 @@ func TestResourceMetricAsLabel(t *testing.T) {
 					source_id      = "source123"
 					name           = "service_name"
 					sql_expression = "getJSON(raw, 'service_name')"
-					type           = "string_low_cardinality"
 					aggregations   = ["uniq"]
 				}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -155,7 +152,6 @@ func TestResourceMetricAsLabel(t *testing.T) {
 					source_id      = "source123"
 					name           = "service_name"
 					sql_expression = "getJSON(raw, 'service_name')"
-					type           = "string_low_cardinality"
 					aggregations   = []
 				}`,
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/provider/resource_metric_update_test.go
+++ b/internal/provider/resource_metric_update_test.go
@@ -79,7 +79,6 @@ func TestResourceMetricUpdateMultipleFields(t *testing.T) {
 					source_id      = "source123"
 					name           = "Original"
 					sql_expression = "JSONExtract(json, 'old', 'String')"
-					type           = "string_low_cardinality"
 					aggregations   = ["count"]
 				}`,
 				Check: resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
@@ -93,14 +92,12 @@ func TestResourceMetricUpdateMultipleFields(t *testing.T) {
 					source_id      = "source123"
 					name           = "Completely Different"
 					sql_expression = "JSONExtract(json, 'new', 'Float')"
-					type           = "float64_delta"
 					aggregations   = ["min", "max", "histogram"]
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "name", "Completely Different"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "sql_expression", "JSONExtract(json, 'new', 'Float')"),
-					resource.TestCheckResourceAttr("logtail_metric.this", "type", "float64_delta"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.#", "3"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.0", "min"),
 					resource.TestCheckResourceAttr("logtail_metric.this", "aggregations.1", "max"),
@@ -117,7 +114,6 @@ func TestResourceMetricUpdateMultipleFields(t *testing.T) {
 						want := metric{
 							Name:          strPtr("Completely Different"),
 							SQLExpression: strPtr("JSONExtract(json, 'new', 'Float')"),
-							Type:          strPtr("float64_delta"),
 							Aggregations:  strSlicePtr("min", "max", "histogram"),
 						}
 						if !reflect.DeepEqual(got, want) {
@@ -212,10 +208,9 @@ func TestResourceMetricSourceIdForcesRecreation(t *testing.T) {
 				}
 				resource "logtail_metric" "this" {
 					source_id      = "source-a"
-					name           = "Metric"
-					sql_expression = "JSONExtract(json, 'x', 'String')"
-					type           = "string_low_cardinality"
-					aggregations   = ["count"]
+					name           = "My metric"
+					sql_expression = "JSONExtractInt(json, 'message_json', 'item_count')"
+					aggregations   = ["avg", "histogram"]
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("logtail_metric.this", "source_id", "source-a"),
@@ -231,10 +226,9 @@ func TestResourceMetricSourceIdForcesRecreation(t *testing.T) {
 				}
 				resource "logtail_metric" "this" {
 					source_id      = "source-b"
-					name           = "Metric"
-					sql_expression = "JSONExtract(json, 'x', 'String')"
-					type           = "string_low_cardinality"
-					aggregations   = ["count"]
+					name           = "My metric"
+					sql_expression = "JSONExtractInt(json, 'message_json', 'item_count')"
+					aggregations   = ["avg", "histogram"]
 				}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("logtail_metric.this", "source_id", "source-b"),
@@ -305,7 +299,6 @@ func TestResourceMetricPatchErrorPropagates(t *testing.T) {
 					source_id      = "source123"
 					name           = "M"
 					sql_expression = "JSONExtract(json, 'x', 'Float')"
-					type           = "float64_delta"
 					aggregations   = ["avg"]
 				}`,
 			},
@@ -319,143 +312,9 @@ func TestResourceMetricPatchErrorPropagates(t *testing.T) {
 					source_id      = "source123"
 					name           = "M"
 					sql_expression = "JSONExtract(json, 'x', 'Float')"
-					type           = "float64_delta"
 					aggregations   = ["sum"]
 				}`,
 				ExpectError: regexp.MustCompile(`PATCH .*?/metrics/1 returned 422.*boom`),
-			},
-		},
-	})
-}
-
-// TestResourceMetricTypeFlipInPlace changes ONLY the `type` field — swapping
-// between a numeric metric and a dimensional (string_low_cardinality) one.
-// The provider should route this through PATCH like any other field, keeping
-// the same resource ID; whether the backend can actually retype the underlying
-// ClickHouse column is a separate server-side question this unit test does
-// not exercise.
-func TestResourceMetricTypeFlipInPlace(t *testing.T) {
-	var data atomic.Value
-	var id atomic.Value
-	var lastPatchBody atomic.Value
-	id.Store(0)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer foo" {
-			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
-		}
-		prefix := "/api/v2/sources/source123/metrics"
-		switch {
-		case r.Method == http.MethodPost && r.RequestURI == prefix:
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			data.Store(body)
-			w.WriteHeader(http.StatusCreated)
-			id.Store(id.Load().(int) + 1)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"%d","attributes":%s}}`, id.Load(), body)))
-		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=1":
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"%d","attributes":%s}],"pagination":{"next":null}}`, id.Load(), data.Load())))
-		case r.Method == http.MethodPatch && r.RequestURI == fmt.Sprintf(`%s/%d`, prefix, id.Load()):
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			lastPatchBody.Store(body)
-			data.Store(body)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"%d","attributes":%s}}`, id.Load(), body)))
-		case r.Method == http.MethodDelete && r.RequestURI == fmt.Sprintf(`%s/%d`, prefix, id.Load()):
-			w.WriteHeader(http.StatusNoContent)
-			data.Store([]byte(nil))
-		default:
-			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
-		}
-	}))
-	defer server.Close()
-
-	typeInBody := func(want string) resource.TestCheckFunc {
-		return func(*terraform.State) error {
-			raw, _ := lastPatchBody.Load().([]byte)
-			var got metric
-			if err := json.Unmarshal(raw, &got); err != nil {
-				return fmt.Errorf("PATCH body not valid JSON: %v (body=%s)", err, string(raw))
-			}
-			if got.Type == nil {
-				return fmt.Errorf("PATCH body missing `type` field (body=%s)", string(raw))
-			}
-			if *got.Type != want {
-				return fmt.Errorf("PATCH body type = %q, want %q (body=%s)", *got.Type, want, string(raw))
-			}
-			return nil
-		}
-	}
-
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			"logtail": func() (*schema.Provider, error) {
-				return New(WithURL(server.URL)), nil
-			},
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: `
-				provider "logtail" {
-					api_token = "foo"
-				}
-				resource "logtail_metric" "this" {
-					source_id      = "source123"
-					name           = "Convertible"
-					sql_expression = "JSONExtract(json, 'val', 'Float')"
-					type           = "float64_delta"
-					aggregations   = ["avg"]
-				}`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
-					resource.TestCheckResourceAttr("logtail_metric.this", "type", "float64_delta"),
-				),
-			},
-			{
-				// Numeric -> dimensional. aggregations/sql_expression swapped
-				// to values that make sense for a string column so the test
-				// mirrors a realistic migration.
-				Config: `
-				provider "logtail" {
-					api_token = "foo"
-				}
-				resource "logtail_metric" "this" {
-					source_id      = "source123"
-					name           = "Convertible"
-					sql_expression = "JSONExtract(json, 'val', 'String')"
-					type           = "string_low_cardinality"
-					aggregations   = ["uniq"]
-				}`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
-					resource.TestCheckResourceAttr("logtail_metric.this", "type", "string_low_cardinality"),
-					typeInBody("string_low_cardinality"),
-				),
-			},
-			{
-				// Dimensional -> integer numeric. Only `type` and `sql_expression`
-				// differ from the previous step to keep focus on the type flip.
-				Config: `
-				provider "logtail" {
-					api_token = "foo"
-				}
-				resource "logtail_metric" "this" {
-					source_id      = "source123"
-					name           = "Convertible"
-					sql_expression = "JSONExtract(json, 'val', 'Int')"
-					type           = "int64_delta"
-					aggregations   = ["uniq"]
-				}`,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("logtail_metric.this", "id", "1"),
-					resource.TestCheckResourceAttr("logtail_metric.this", "type", "int64_delta"),
-					typeInBody("int64_delta"),
-				),
 			},
 		},
 	})


### PR DESCRIPTION
## Problem

`logtail_metric.type`is on its way out: the Telemetry API now defaults the type to `string_low_cardinality` for Labels (no aggregations) and `float64_delta` for Metrics (any aggregations), and re-defaults the type when an update crosses the label ↔ metric boundary without an explicit `type`.

The plan was to drop `type` from the API entirely, but some legacy sources still rely on it. Let's mark it optional and deprecated in Terraform. In overwhelming majority of cases, it's absolutely safe to omit.

## Fix

- Mark `type` as `Optional` + `Computed` + `Deprecated` on `logtail_metric`. The schema still validates the historical set of values so existing configs keep planning cleanly.
- Stop sending `type` in create/PATCH requests when the user didn't set it in HCL. `load()` uses `GetOkExists`, which for a Computed attribute echoes the API-returned value back, so the previous behaviour would have leaked `"type":""` (or the prior server value) into every request after the first apply. A new `loadMetric` helper sources `type` from `rawConfig` via `stringFromResourceData`, so it's sent only when explicitly configured — and the backend's new defaulting/re-defaulting logic handles the rest.
- Strip `type` from the `examples/advanced` and `examples/collector` metric configs and from the unit tests. Drop `TestResourceMetricTypeFlipInPlace`: flipping a field the backend now derives is no longer a behaviour worth locking in.
- Regenerate `docs/resources/metric.md` and `docs/data-sources/metric.md` (the `type` row now reads `Deprecated`, and the resource description covers Labels too) and bump `VERSION` / the advanced example's `versions.tf` to `10.15.1`.

> Backwards compatibility: existing configs that still set `type` keep working unchanged — the value is forwarded as before and validated against the same set. Only the `Required` flag flips to `Optional`.

