### PR TITLE
T-17220 Run tests on ubuntu only, with faster results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,6 @@ on:
     - cron: '0 3 * * *'
 jobs:
   test:
-    strategy:
-      # The suite is dominated by acceptance tests that each spin up a real
-      # `terraform init` + `apply` (~5s per test), so one job takes 7+ minutes.
-      # Round-robin the top-level test functions into 4 batches to finish in
-      # about the same time as the E2E jobs. Update the batch list and the
-      # `4` in the Test step together when changing the batch count.
-      matrix:
-        batch: [0, 1, 2, 3]
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       # Checkout must precede setup-go so its cache can be keyed on go.sum.
@@ -38,15 +29,7 @@ jobs:
         env:
           # Skip terraform's checkpoint version-check call in every init the tests run.
           CHECKPOINT_DISABLE: "1"
-        run: |
-          ALL_TESTS="$(go test -list '.*' ./... | grep '^Test' | sort -u)"
-          BATCH_TESTS="$(echo "$ALL_TESTS" | awk 'NR % 4 == ${{ matrix.batch }}' | paste -sd '|' -)"
-          if [ -z "$BATCH_TESTS" ]; then
-            echo "Batch ${{ matrix.batch }} selected no tests - is the test listing broken?"
-            exit 1
-          fi
-          echo "Batch ${{ matrix.batch }} runs $(echo "$BATCH_TESTS" | tr '|' '\n' | wc -l) of $(echo "$ALL_TESTS" | wc -l) tests"
-          go test -timeout 10m -run "^($BATCH_TESTS)$" ./...
+        run: go test -timeout 10m ./...
 
   e2e_test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
   schedule:
@@ -10,28 +10,43 @@ on:
 jobs:
   test:
     strategy:
+      # The suite is dominated by acceptance tests that each spin up a real
+      # `terraform init` + `apply` (~5s per test), so one job takes 7+ minutes.
+      # Round-robin the top-level test functions into 4 batches to finish in
+      # about the same time as the E2E jobs. Update the batch list and the
+      # `4` in the Test step together when changing the batch count.
       matrix:
-        go-version: ['1.23.x']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        batch: [0, 1, 2, 3]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
+      # Checkout must precede setup-go so its cache can be keyed on go.sum.
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '1.23.x'
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 'latest'
-          # Disable the wrapper: on Windows it creates a `terraform` file with
-          # no extension that is not discoverable via PATHEXT, so go test falls
-          # back to hc-install and trips the expired GPG check.
+          # Disable the wrapper: the acceptance-test driver must exec the real
+          # terraform binary, not the wrapper script shadowing it on PATH.
           terraform_wrapper: false
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Test
-        run: go test -timeout 20m ./...
+        env:
+          # Skip terraform's checkpoint version-check call in every init the tests run.
+          CHECKPOINT_DISABLE: "1"
+        run: |
+          ALL_TESTS="$(go test -list '.*' ./... | grep '^Test' | sort -u)"
+          BATCH_TESTS="$(echo "$ALL_TESTS" | awk 'NR % 4 == ${{ matrix.batch }}' | paste -sd '|' -)"
+          if [ -z "$BATCH_TESTS" ]; then
+            echo "Batch ${{ matrix.batch }} selected no tests - is the test listing broken?"
+            exit 1
+          fi
+          echo "Batch ${{ matrix.batch }} runs $(echo "$BATCH_TESTS" | tr '|' '\n' | wc -l) of $(echo "$ALL_TESTS" | wc -l) tests"
+          go test -timeout 10m -run "^($BATCH_TESTS)$" ./...
 
   e2e_test:
     strategy:
@@ -41,16 +56,17 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+      # Checkout must precede setup-go so its cache can be keyed on go.sum.
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ matrix.terraform-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Add resources via Terraform
         run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="apply --auto-approve --input=false"
         env:
@@ -88,16 +104,17 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+      # Checkout must precede setup-go so its cache can be keyed on go.sum.
+      - name: Checkout code
+        uses: actions/checkout@v7
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ matrix.terraform-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Assemble combined examples
         run: |
           mkdir -p combined-e2e

--- a/internal/provider/data_dashboard_template_test.go
+++ b/internal/provider/data_dashboard_template_test.go
@@ -164,6 +164,8 @@ func TestDataSourceDashboardTemplate(t *testing.T) {
 				Config: `
 				provider "logtail" {
 					api_token = "foo"
+					# Don't sit through the 150s retry backoff for the simulated 500.
+					api_retry_max = 0
 				}
 
 				data "logtail_dashboard_template" "broken_export" {

--- a/internal/provider/data_dashboard_test.go
+++ b/internal/provider/data_dashboard_test.go
@@ -165,6 +165,8 @@ func TestDataSourceDashboard(t *testing.T) {
 				Config: `
 				provider "logtail" {
 					api_token = "foo"
+					# Don't sit through the 150s retry backoff for the simulated 500.
+					api_retry_max = 0
 				}
 
 				data "logtail_dashboard" "broken_export" {


### PR DESCRIPTION
Fixes brittle/slow test runs, especially on Windows.

## What changed

**Drop the macos/windows matrix.** Windows runs regularly hit the 10m+ range ([13m51s in the reference run](https://github.com/BetterStackHQ/terraform-provider-logtail/actions/runs/28514750504)) and flake on timeouts, and no test failure has ever been platform-specific. The suite now runs as a single ubuntu job.

**Kill the 300s of retry backoff hiding in two tests.** Per-test timing showed `TestDataSourceDashboard` and `TestDataSourceDashboardTemplate` each took **151s** — their "broken export" step returns a mock 500, and the client sat through its full default retry backoff (`api_retry_max = 4` × waits 10+20+40+80s = 150s). Those steps now set `api_retry_max = 0` (retry behavior itself is covered by `client_test.go`), dropping each test to ~1s and **the whole suite from 382s to ~85s**.

**Shave per-job overhead** (was ~30s of module download + compile per job):
- checkout now precedes `setup-go@v6`, so Go module + build caching actually kicks in (`setup-go@v2` never cached anything)
- `CHECKPOINT_DISABLE=1` makes every `terraform init` the acceptance tests spawn skip its checkpoint version-check call
- `checkout`/`setup-terraform` bumped to current majors across all jobs (also silences the Node 20 deprecation warnings); the e2e jobs benefit from the Go cache too since they rebuild the provider every run

**Fix the `push` trigger: `master` → `main`.** The default branch is `main`, so the tests-on-push (and thus `notify-linear` on push failures) never actually ran on the default branch — only PRs and the nightly schedule.

## Batching: tried, then dropped

An earlier revision split the tests into a 4-way matrix (CI-verified green, batches at ~1.1m each). After the retry fix the unbatched job runs in **2m07s** — comparable to the `e2e_combined` jobs — so the batching machinery wasn't worth its complexity and was removed. If the suite outgrows this, the recipe to bring back: `matrix: batch: ['1/4', '2/4', '3/4', '4/4']` as display labels, with the actual split done by `strategy.job-index` / `strategy.job-total` (`go test -list '.*' ./... | grep '^Test' | sort -u | awk "NR % total == index"` → `-run "^(A|B|…)$"`), so the batch count is just the length of the matrix list.

## Verified

- Final CI run: `test` green in 127s; all e2e jobs green.
- The two fixed tests pass locally in ~1s each.
- `make gen` produced no doc changes (CI/test-only change, no VERSION bump needed).

## Note for merging

The required-check name changes from `test (1.23.x, ubuntu-latest)` to `test` — branch protection rules may need updating.

uptime provider intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
