### PR TITLE
T-19124 Keep user-configured chart_id in the dashboard_alert data source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.2
+VERSION := 10.15.3
 .PHONY: test build
 
 help:

--- a/internal/provider/data_dashboard_alert.go
+++ b/internal/provider/data_dashboard_alert.go
@@ -99,9 +99,12 @@ func dashboardAlertLookup(ctx context.Context, d *schema.ResourceData, meta inte
 			if err := d.Set("dashboard_id", dashboardID); err != nil {
 				return diag.FromErr(err)
 			}
-			if err := d.Set("chart_id", chartID); err != nil {
-				return diag.FromErr(err)
-			}
+			// chart_id deliberately keeps the user-configured value (possibly the
+			// composite "dashboard_id/chart_id"). Overwriting it with the bare ID
+			// makes state disagree with config on every plan, and data sources have
+			// no DiffSuppressFunc to hide that - Terraform 0.13 then re-reads the
+			// data source during the plan walk and reports a "read" change whenever
+			// the alert was touched in between.
 
 			return alertCopyAttrs(d, &item.Attributes)
 		}

--- a/internal/provider/data_dashboard_alert_test.go
+++ b/internal/provider/data_dashboard_alert_test.go
@@ -48,11 +48,33 @@ func TestDataSourceDashboardAlert(t *testing.T) {
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "id", "1/10/100"),
+					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "chart_id", "10"),
 					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "name", "High Error Rate"),
 					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "alert_type", "threshold"),
 					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "operator", "higher_than"),
 					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "value", "100"),
 					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "email", "true"),
+				),
+			},
+			{
+				// A composite "dashboard_id/chart_id" (what logtail_dashboard_chart.id
+				// yields) must survive in state as configured - normalizing it to the
+				// bare ID would make every plan re-read the data source on Terraform 0.13.
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				data "logtail_dashboard_alert" "this" {
+					dashboard_id = "1"
+					chart_id     = "1/10"
+					name         = "High Error Rate"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "id", "1/10/100"),
+					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "chart_id", "1/10"),
+					resource.TestCheckResourceAttr("data.logtail_dashboard_alert.this", "name", "High Error Rate"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes the flaky `e2e_combined (0.13)` failure at *Plan resources via Terraform - must be empty* (first seen on the `965dae0` push run).

## Root cause

Three things had to line up:

1. `dashboardAlertLookup` overwrote `chart_id` in state with the bare chart ID, while the example config passes the composite `"dashboard_id/chart_id"` that `logtail_dashboard_chart.id` yields. So state never matched config for that attribute. The managed resource has a `DiffSuppressFunc` bridging composite vs bare, but **diff-suppress never applies to data sources** — Terraform core compares config to state directly.
2. On Terraform 0.13, the plan walk (`dataObjectHasChanges` in `eval_read_data_plan.go`) sees that mismatch, concludes the config changed, and re-reads the data source a **second** time (the refresh walk already read it once and silently absorbs drift).
3. When the backend touches the alert between those two reads (`updated_at` jumped to `12:22:26.603`, milliseconds before the plan-walk read), 0.13 records `actions: ["read"]` in `resource_changes` — which the empty-plan check counts as a planned change.

The plan annotation *"(config refers to values not yet known)"* is a red herring: Terraform 0.13 hardcodes that line for every `Read` action, deferred or not.

## Fix

Keep the user-configured `chart_id` in state instead of normalizing it to the bare ID (normalization still happens where it belongs — when building the API path). With config and state agreeing, the plan walk plans no read, and the refresh walk absorbs `updated_at` drift silently.

## Verification

Reproduced and verified against a mock API (bumping `updated_at` on every read to simulate the backend touch), running real Terraform 0.13.7 and 1.10 binaries:

| chart_id in config | updated_at drifts between reads | TF | before fix | after fix |
|---|---|---|---|---|
| composite | yes | 0.13 | **fails** (reproduces CI byte-for-byte) | passes |
| composite | no | 0.13 | passes (why nightly was green) | passes |
| composite | yes | 1.10 | passes | passes |
| bare | yes | 0.13 | passes | passes |

Unit test extended with a composite-`chart_id` step asserting the configured value survives in state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
