### PR TITLE
Look up dashboards by ID directly instead of scanning the paginated list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.4
+VERSION := 10.15.3
 .PHONY: test build
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.3
+VERSION := 10.15.4
 .PHONY: test build
 
 help:

--- a/internal/provider/data_dashboard.go
+++ b/internal/provider/data_dashboard.go
@@ -179,40 +179,20 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 		return &tr, json.Unmarshal(body, &tr)
 	}
 
-	// If ID is provided, look up directly by ID
+	// If ID is provided, look up directly by ID. Never search the paginated
+	// list for an ID: concurrent dashboard deletions shift items between
+	// pages mid-iteration, so an existing dashboard can be skipped.
 	if id != "" {
-		// First, verify the dashboard exists in the list and get its details
-		// We need to search through all pages to find the dashboard
-		var dashboardExists bool
-		var dashboardName string
-		var dashboardTeamName *string
-
-		page := 1
-		for {
-			res, err := fetch(page)
-			if err != nil {
-				return diag.FromErr(err)
-			}
-
-			for _, e := range res.Data {
-				if e.ID == id {
-					dashboardExists = true
-					if e.Attributes.Name != nil {
-						dashboardName = *e.Attributes.Name
-					}
-					dashboardTeamName = e.Attributes.TeamName
-					break
-				}
-			}
-
-			if dashboardExists || res.Pagination.Next == "" {
-				break
-			}
-			page++
+		var out dashboardHTTPResponse
+		if err, ok := resourceReadWithBaseURL(ctx, meta, meta.(*client).TelemetryBaseURL(), fmt.Sprintf("/api/v2/dashboards/%s", url.PathEscape(id)), &out); err != nil {
+			return err
+		} else if !ok {
+			return diag.Errorf("dashboard with ID %s not found", id)
 		}
 
-		if !dashboardExists {
-			return diag.Errorf("dashboard with ID %s not found in dashboards list", id)
+		var dashboardName string
+		if out.Data.Attributes.Name != nil {
+			dashboardName = *out.Data.Attributes.Name
 		}
 
 		// If both ID and name are provided, validate they match
@@ -221,17 +201,12 @@ func dataSourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		// If team_name is provided, validate it matches
-		if teamName != "" && (dashboardTeamName == nil || !strings.EqualFold(*dashboardTeamName, teamName)) {
+		if teamName != "" && (out.Data.Attributes.TeamName == nil || !strings.EqualFold(*out.Data.Attributes.TeamName, teamName)) {
 			actualTeamName := ""
-			if dashboardTeamName != nil {
-				actualTeamName = *dashboardTeamName
+			if out.Data.Attributes.TeamName != nil {
+				actualTeamName = *out.Data.Attributes.TeamName
 			}
 			return diag.Errorf("dashboard with ID %s has team_name %q, but requested team_name is %q", id, actualTeamName, teamName)
-		}
-
-		var out dashboardHTTPResponse
-		if err, ok := resourceReadWithBaseURL(ctx, meta, meta.(*client).TelemetryBaseURL(), fmt.Sprintf("/api/v2/dashboards/%s", url.PathEscape(id)), &out); !ok {
-			return diag.Errorf("dashboard %q was found but couldn't be exported: %v", dashboardName, err)
 		}
 
 		d.SetId(id)

--- a/internal/provider/data_dashboard_test.go
+++ b/internal/provider/data_dashboard_test.go
@@ -23,7 +23,10 @@ func TestDataSourceDashboard(t *testing.T) {
 
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/dashboards/123":
-			_, _ = w.Write([]byte(`{"data":{"id":"123","type":"dashboard","attributes":{"name":"Unique Dashboard A","team_id":123,"created_at":"2025-01-20T01:00:00.000Z","updated_at":"2025-01-20T01:30:00.000Z"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"id":"123","type":"dashboard","attributes":{"name":"Unique Dashboard A","team_id":123,"team_name":"test-team","created_at":"2025-01-20T01:00:00.000Z","updated_at":"2025-01-20T01:30:00.000Z"}}}`))
+		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/dashboards/999":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":"Resource with the provided ID was not found"}`))
 		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/dashboards/123/export":
 			_, _ = w.Write([]byte(`{"id":"123","name":"Unique Dashboard A","data":{"refresh_interval":30,"date_range_from":"now-1h","date_range_to":"now","charts":[],"sections":[]}}`))
 		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/dashboards/234":
@@ -160,7 +163,40 @@ func TestDataSourceDashboard(t *testing.T) {
 					t.Log("step 5 - lookup by ID with mismatched name (should error)")
 				},
 			},
-			// Step 6 - lookup by ID with broken export (should error)
+			// Step 6 - lookup by non-existent ID (should error, without listing dashboards)
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				data "logtail_dashboard" "missing" {
+					id = "999"
+				}
+				`,
+				ExpectError: regexp.MustCompile(`dashboard with ID 999 not found`),
+				PreConfig: func() {
+					t.Log("step 6 - lookup by non-existent ID (should error)")
+				},
+			},
+			// Step 7 - lookup by ID with mismatched team_name (should error)
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				data "logtail_dashboard" "team_mismatch" {
+					id        = "123"
+					team_name = "other-team"
+				}
+				`,
+				ExpectError: regexp.MustCompile(`dashboard with ID 123 has team_name "test-team", but requested team_name is "other-team"`),
+				PreConfig: func() {
+					t.Log("step 7 - lookup by ID with mismatched team_name (should error)")
+				},
+			},
+			// Step 8 - lookup by ID with broken export (should error)
 			{
 				Config: `
 				provider "logtail" {
@@ -175,7 +211,7 @@ func TestDataSourceDashboard(t *testing.T) {
 				`,
 				ExpectError: regexp.MustCompile(`dashboard "Dashboard with broken export" was found but couldn't be exported`),
 				PreConfig: func() {
-					t.Log("step 6 - lookup by ID with broken export (should error)")
+					t.Log("step 8 - lookup by ID with broken export (should error)")
 				},
 			},
 		},


### PR DESCRIPTION
## What

A performance improvement for `data.logtail_dashboard`: when `id` is set, the data source now calls `GET /api/v2/dashboards/{id}` directly (the same endpoint the resource read uses) instead of paging through the whole `GET /api/v2/dashboards` list looking for the ID — O(1) instead of O(pages) for teams with many dashboards. The show endpoint returns `name` and `team_name`, so the optional name/team_name cross-validations keep working unchanged. The name-lookup path still pages through the list, as it has to.

Tests: by-ID steps now mock the direct GET; added steps for a non-existent ID (404 → clear error, no list calls) and a `team_name` mismatch on by-ID lookup.

## How this was discovered

Via a high-concurrency E2E failure: several `tests` workflow runs were dispatched near-simultaneously on 2026-07-03, and [`e2e_combined (1.0)` in run 28657860380](https://github.com/BetterStackHQ/terraform-provider-logtail/actions/runs/28657860380/job/84991201693) failed with `dashboard with ID 1060928 not found in dashboards list` even though the dashboard existed (the same job was reading its charts at that moment). Concurrent runs' destroys were shrinking the list between page fetches, and offset pagination shifts items to earlier pages, so the scan skipped the target — a race the direct GET doesn't have. 429-induced retry backoff had stretched the scan to ~40s, making the window wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
