### PR TITLE
Remove the chart/section overlap in the example dashboard layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Every resource and data source has an example under `examples/resources/<type>/r
 
 Each example holds only its own resource and may reference siblings by their conventional name (e.g. `logtail_dashboard.production`); the union must be one valid config. Data sources must resolve by a **unique** key — a config resource's `id`/`table_name`, or a permanent uniquely-named fixture seeded in the E2E team — never a duplicate-prone name (a name shared with a freshly-created resource deadlocks `destroy` once runs overlap or leave leftovers).
 
+Dashboard chart/section coordinates pinned across the merged examples must not overlap — the server tolerates overlaps but schedules a debounced layout consolidation that moves items, breaking the empty-`plan` check for any job running longer than ~5 minutes. `TestExamplesDashboardLayoutHasNoOverlaps` enforces this in `make test`.
+
 `examples/` itself is the runnable **basic** example. `examples/connection/` runs as its own E2E config because it needs a global API token; the combined run denylists it and `logtail_source_aws_account` (needs AWS credentials).
 
 **Seeded fixtures** the examples reference (create once in the E2E team, never delete): collector `My Existing Collector`, `My Existing Source Group`, errors application `My Existing Errors Application` and group `My Existing Errors Application Group`, `My Existing Dashboard Group`, `My Existing Exploration`, `My Existing Exploration Group`; escalation policy `My Existing Escalation Policy` (used by the alert resources); and the connected source-code repositories `BetterStackHQ/test-blame-repo` (GitHub integration) and `better-stack/test-blame-repo` (GitLab integration), linked by the `errors_application` examples.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.4
+VERSION := 10.15.3
 .PHONY: test build
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.3
+VERSION := 10.15.4
 .PHONY: test build
 
 help:

--- a/docs/resources/dashboard_chart.md
+++ b/docs/resources/dashboard_chart.md
@@ -136,12 +136,13 @@ resource "logtail_dashboard_chart" "tuned_errors" {
 }
 
 # Live tail chart - where_condition filters the stream
+# y = 9 places it right below the "Performance" section divider at y = 8
 resource "logtail_dashboard_chart" "live_errors" {
   dashboard_id = logtail_dashboard.production.id
   chart_type   = "tail_chart"
   name         = "Live errors"
   x            = 0
-  y            = 8
+  y            = 9
   w            = 12
   h            = 6
 

--- a/examples/resources/logtail_dashboard_chart/resource.tf
+++ b/examples/resources/logtail_dashboard_chart/resource.tf
@@ -121,12 +121,13 @@ resource "logtail_dashboard_chart" "tuned_errors" {
 }
 
 # Live tail chart - where_condition filters the stream
+# y = 9 places it right below the "Performance" section divider at y = 8
 resource "logtail_dashboard_chart" "live_errors" {
   dashboard_id = logtail_dashboard.production.id
   chart_type   = "tail_chart"
   name         = "Live errors"
   x            = 0
-  y            = 8
+  y            = 9
   w            = 12
   h            = 6
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-retryablehttp v0.7.7
+	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	golang.org/x/time v0.12.0
@@ -37,7 +38,6 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.9.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.22.0 // indirect
 	github.com/hashicorp/terraform-json v0.24.0 // indirect

--- a/internal/provider/examples_layout_test.go
+++ b/internal/provider/examples_layout_test.go
@@ -1,0 +1,150 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// The dashboards API accepts overlapping chart/section positions, but responds
+// by scheduling a debounced server-side layout consolidation that later moves
+// items around. Moved items no longer match the coordinates pinned in the
+// examples, so the e2e_combined empty-plan check fails whenever a job outlives
+// the debounce. This test replays the server's overlap check on the merged
+// example configuration: charts are [x, y, w, h] rectangles, sections span the
+// full grid width with height 1.
+const dashboardGridWidth = 12
+
+type layoutItem struct {
+	address    string
+	pos        string
+	x, y, w, h int
+}
+
+func TestExamplesDashboardLayoutHasNoOverlaps(t *testing.T) {
+	files, err := exampleTerraformFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no example .tf files found - directory layout changed?")
+	}
+
+	parser := hclparse.NewParser()
+	itemsByDashboard := map[string][]layoutItem{}
+	for _, file := range files {
+		f, diags := parser.ParseHCLFile(file)
+		if diags.HasErrors() {
+			t.Fatalf("parsing %s: %v", file, diags)
+		}
+		for _, block := range f.Body.(*hclsyntax.Body).Blocks {
+			if block.Type != "resource" || len(block.Labels) != 2 {
+				continue
+			}
+			item := layoutItem{
+				address: block.Labels[0] + "." + block.Labels[1],
+				pos:     fmt.Sprintf("%s:%d", file, block.DefRange().Start.Line),
+			}
+			attrs := block.Body.Attributes
+			switch block.Labels[0] {
+			case "logtail_dashboard_chart":
+				coords, ok := intAttrs(attrs, "x", "y", "w", "h")
+				if !ok {
+					continue // no pinned coordinates - the server auto-places without overlap
+				}
+				item.x, item.y, item.w, item.h = coords[0], coords[1], coords[2], coords[3]
+			case "logtail_dashboard_section":
+				coords, ok := intAttrs(attrs, "y")
+				if !ok {
+					continue
+				}
+				item.x, item.y, item.w, item.h = 0, coords[0], dashboardGridWidth, 1
+			default:
+				continue
+			}
+			key := referenceString(attrs["dashboard_id"])
+			itemsByDashboard[key] = append(itemsByDashboard[key], item)
+		}
+	}
+
+	if len(itemsByDashboard) == 0 {
+		t.Fatal("no dashboard charts/sections found in examples - parsing broke?")
+	}
+
+	for dashboard, items := range itemsByDashboard {
+		for i, a := range items {
+			for _, b := range items[i+1:] {
+				if a.x+a.w > b.x && a.x < b.x+b.w && a.y+a.h > b.y && a.y < b.y+b.h {
+					t.Errorf("dashboard %s: %s (%s) overlaps %s (%s) - the server would consolidate the layout and move them, breaking the e2e_combined empty-plan check",
+						dashboard, a.address, a.pos, b.address, b.pos)
+				}
+			}
+		}
+	}
+}
+
+// exampleTerraformFiles mirrors the e2e_combined "Assemble combined examples"
+// workflow step: the basic example's scaffolding plus every documented example.
+func exampleTerraformFiles() ([]string, error) {
+	var files []string
+	for _, pattern := range []string{"../../examples/*.tf", "../../examples/resources/*/*.tf", "../../examples/data-sources/*/*.tf"} {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, matches...)
+	}
+	for _, file := range files {
+		if _, err := os.Stat(file); err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
+}
+
+// intAttrs returns the literal integer values of the named attributes,
+// or ok=false if any of them is absent or not a literal number.
+func intAttrs(attrs hclsyntax.Attributes, names ...string) ([]int, bool) {
+	values := make([]int, 0, len(names))
+	for _, name := range names {
+		attr, found := attrs[name]
+		if !found {
+			return nil, false
+		}
+		val, diags := attr.Expr.Value(nil)
+		if diags.HasErrors() || !val.Type().IsPrimitiveType() {
+			return nil, false
+		}
+		i, _ := val.AsBigFloat().Int64()
+		values = append(values, int(i))
+	}
+	return values, true
+}
+
+// referenceString renders an attribute reference like
+// `logtail_dashboard.production.id` back to its traversal string, so charts
+// can be grouped by the dashboard resource they attach to.
+func referenceString(attr *hclsyntax.Attribute) string {
+	if attr == nil {
+		return "(none)"
+	}
+	vars := attr.Expr.Variables()
+	if len(vars) == 0 {
+		return "(literal)"
+	}
+	out := ""
+	for _, step := range vars[0] {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			out = s.Name
+		case hcl.TraverseAttr:
+			out += "." + s.Name
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## What

Makes the example dashboard layout internally consistent: the `live_errors` chart (`y=8, h=6`) overlapped the `Performance` section divider (`y=8` — sections span the full grid width with height 1), which isn't a stable layout the server would keep. The chart moves to `y = 9`, directly below the divider, so the merged `production` dashboard is overlap-free.

To keep it that way, `TestExamplesDashboardLayoutHasNoOverlaps` parses every example `.tf` the combined E2E assembles and replays the server's overlap check (charts as `[x, y, w, h]` rects, sections as full-width height-1 rows, grouped by the referenced dashboard), failing with file:line pointers if a future example reintroduces an overlap — it flagged this exact overlap before the coordinate fix. The constraint is also documented in CLAUDE.md. `go.mod`: `hashicorp/hcl/v2` promoted from indirect to direct (used by the new test).

## How this was discovered

Via a high-concurrency E2E failure: several `tests` workflow runs were dispatched near-simultaneously on 2026-07-03, and the empty-plan check failed on both [`e2e_combined (0.13)`](https://github.com/BetterStackHQ/terraform-provider-logtail/actions/runs/28657852641/job/84991178524) and [`e2e_combined (1.0)`](https://github.com/BetterStackHQ/terraform-provider-logtail/actions/runs/28657852641/job/84991178549) in run 28657852641 with sections drifting from their configured positions (`y = 15 -> 16`, `y = 14 -> 8`). The dashboards API tolerates overlapping positions but schedules a debounced (5 min) server-side layout consolidation that moves items. Normally the E2E finishes before the debounce fires; with concurrent runs slowing a job past ~5 minutes via 429 backoff, the consolidation landed mid-test and moved the sections. With no overlaps the consolidation is never scheduled, no matter how long a job runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
