### PR TITLE
U-9088 Ignore unknown API fields in connection data_sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.3
+VERSION := 10.15.5
 .PHONY: test build
 
 help:

--- a/internal/provider/ptr.go
+++ b/internal/provider/ptr.go
@@ -123,3 +123,22 @@ func load(d *schema.ResourceData, key string, receiver interface{}) {
 		panic(fmt.Errorf("unexpected type %T", receiver))
 	}
 }
+
+// dropUnknownKeys removes keys not defined in the schema from raw API maps,
+// so fields newly added to the API are ignored instead of failing d.Set.
+func dropUnknownKeys(in *[]map[string]interface{}, s map[string]*schema.Schema) *[]map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make([]map[string]interface{}, len(*in))
+	for i, m := range *in {
+		filtered := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			if _, ok := s[k]; ok {
+				filtered[k] = v
+			}
+		}
+		out[i] = filtered
+	}
+	return &out
+}

--- a/internal/provider/resource_connection.go
+++ b/internal/provider/resource_connection.go
@@ -114,27 +114,29 @@ var connectionSchema = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Computed:    true,
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"source_name": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"source_id": {
-					Type:     schema.TypeInt,
-					Computed: true,
-				},
-				"team_name": {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
-				"data_sources": {
-					Type:     schema.TypeList,
-					Computed: true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
-				},
-			},
+			Schema: connectionDataSourceSchema,
+		},
+	},
+}
+
+var connectionDataSourceSchema = map[string]*schema.Schema{
+	"source_name": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"source_id": {
+		Type:     schema.TypeInt,
+		Computed: true,
+	},
+	"team_name": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"data_sources": {
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
 		},
 	},
 }
@@ -289,6 +291,7 @@ func connectionCopyAttrs(d *schema.ResourceData, in *connection) diag.Diagnostic
 	if err := d.Set("created_by", in.CreatedBy); err != nil {
 		derr = append(derr, diag.FromErr(err)[0])
 	}
+	in.DataSources = dropUnknownKeys(in.DataSources, connectionDataSourceSchema)
 	if in.DataSources != nil && *in.DataSources != nil {
 		if err := d.Set("data_sources", *in.DataSources); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])

--- a/internal/provider/resource_connection_test.go
+++ b/internal/provider/resource_connection_test.go
@@ -103,3 +103,93 @@ func TestResourceConnection(t *testing.T) {
 		},
 	})
 }
+
+func TestResourceConnectionUnknownDataSourceField(t *testing.T) {
+	var data atomic.Value
+	// The API returns data_sources entries with fields unknown to the provider schema;
+	// they must be ignored instead of failing the plan/refresh with "Invalid address to set".
+	dataSources := []interface{}{
+		map[string]interface{}{
+			"source_name":          "my-source",
+			"source_id":            42,
+			"team_name":            "Test Team",
+			"data_sources":         []interface{}{"logs", "metrics"},
+			"retention_days":       30,
+			"another_future_field": "ignored",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		prefix := "/api/v1/connections"
+		id := "1"
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == prefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body = inject(t, body, "host", "us-east-9-connect.betterstackdata.com")
+			body = inject(t, body, "port", 443)
+			body = inject(t, body, "data_sources", dataSources)
+
+			data.Store(body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, body)))
+		case r.Method == http.MethodGet && r.RequestURI == prefix+"/"+id:
+			body := data.Load().([]byte)
+			body = inject(t, body, "data_sources", dataSources)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, body)))
+		case r.Method == http.MethodDelete && r.RequestURI == prefix+"/"+id:
+			w.WriteHeader(http.StatusNoContent)
+			data.Store([]byte(nil))
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	config := `
+	provider "logtail" {
+		api_token = "foo"
+	}
+
+	resource "logtail_connection" "this" {
+		client_type = "clickhouse"
+		team_names  = ["Test Team"]
+	}
+	`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create; unknown data_sources fields must be ignored, known ones kept.
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("logtail_connection.this", "id"),
+					resource.TestCheckResourceAttr("logtail_connection.this", "data_sources.#", "1"),
+					resource.TestCheckResourceAttr("logtail_connection.this", "data_sources.0.source_name", "my-source"),
+					resource.TestCheckResourceAttr("logtail_connection.this", "data_sources.0.source_id", "42"),
+					resource.TestCheckResourceAttr("logtail_connection.this", "data_sources.0.team_name", "Test Team"),
+					resource.TestCheckResourceAttr("logtail_connection.this", "data_sources.0.data_sources.#", "2"),
+					resource.TestCheckNoResourceAttr("logtail_connection.this", "data_sources.0.retention_days"),
+					resource.TestCheckNoResourceAttr("logtail_connection.this", "data_sources.0.another_future_field"),
+				),
+			},
+			// Step 2 - refresh + plan must not fail on the unknown fields either.
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem

Sibling PR to BetterStackHQ/terraform-provider-better-uptime#224 — the Better Uptime provider broke twice (issues [#49](https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/49), [#222](https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/222)) when a field was added to an API response, and this provider has the same latent crash-class site.

Go's JSON decoding into structs already ignores unknown fields, so most of the provider is safe. The exception is `logtail_connection.data_sources`: entries are decoded into raw `[]map[string]interface{}` and passed verbatim to `d.Set` against the fixed-key schema. A field newly added to the API's data_sources entries would make every plan/refresh touching a connection fail with `Invalid address to set: []string{"data_sources", "0", "<new_field>"}`.

## Fix

New `dropUnknownKeys` helper filters raw API maps against the schema before setting state, so the schema stays the single source of truth and fields newly added to the API are silently ignored instead of breaking the provider. The `data_sources` element schema is extracted into `connectionDataSourceSchema` so the filter and the resource schema share one definition.

Audited all other resources: `data_sources` was the only crash-class site (dashboard `data` and chart/exploration `settings` are JSON strings; `created_by` and `scrape_request_headers` are `TypeMap`, which accepts arbitrary keys).

## Test

`TestResourceConnectionUnknownDataSourceField` has the mock API return `data_sources` entries with unknown fields (`retention_days`, `another_future_field`) on both create and refresh. Without the fix it fails with `Invalid address to set: []string{"data_sources", "0", "another_future_field"}`; with it, known fields land in state and unknown ones are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
