### PR TITLE
T-17502 Register the fastly source platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.8
+VERSION := 10.15.10
 .PHONY: test build
 
 help:

--- a/docs/data-sources/source.md
+++ b/docs/data-sources/source.md
@@ -64,6 +64,7 @@ When importing an existing source, leave `data_region` unset in your configurati
     - `dotnet`
     - `elasticsearch`
     - `erlang`
+    - `fastly`
     - `filebeat`
     - `flights`
     - `fluentbit`

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -119,6 +119,7 @@ resource "logtail_source" "configured" {
     - `dotnet`
     - `elasticsearch`
     - `erlang`
+    - `fastly`
     - `filebeat`
     - `flights`
     - `fluentbit`

--- a/internal/provider/resource_source.go
+++ b/internal/provider/resource_source.go
@@ -33,6 +33,7 @@ var platformTypes = []string{
 	"dotnet",
 	"elasticsearch",
 	"erlang",
+	"fastly",
 	"filebeat",
 	"flights",
 	"fluentbit",


### PR DESCRIPTION
## Why

The `fastly` platform was added to telemetry in BetterStackHQ/logtail#15436 (T-17502) and is API-creatable, so the daily `Dev::PlatformListCheckerWorker` alert in #telemetry flags the provider's resource and data-source docs until a release includes it.

## What

Mirrors #87 (cloudflare_prometheus_exporter):
- add `fastly` to `platformTypes` in `internal/provider/resource_source.go` (both the resource and data-source docs derive from this list)
- regenerate docs via `make gen`
- bump Makefile `VERSION` to `10.15.10` (intended release; latest tag is `v10.15.9` — the checked-in `10.15.8` had drifted)

## Release

The alert clears only once a new version is published — after merging, push the `v10.15.10` tag onto the squash-merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)