### PR TITLE
SH-1002 [CI] Update GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,25 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 'latest'
       - run: make lint
   check_docs:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 'latest'
       - name: Generate docs automatically
         run: make gen
       - name: Check no versioned file has been updated
-        uses: numtide/clean-git-action@v1
+        run: git add -A && git diff --cached --exit-code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,26 +22,26 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v7
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           # These secrets are configured for the repository:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.2.0
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> 1.26'
           args: release --clean


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions (forced to Node 24 since June 2nd, 2026; Node 20 removed from runners on September 16th, 2026). `build.yml` and `release.yml` were running actions on Node 12/16/20; `test.yml` was already up to date. This bumps everything to the same versions `test.yml` already uses (all Node 24):

- `actions/checkout` `v3` / `v2.3.4` → `v7`
- `actions/setup-go` `v4` / `v2` → `v6`
- `hashicorp/setup-terraform` `v3` → `v4`
- `crazy-max/ghaction-import-gpg` `v5` → `v7` (inputs `gpg_private_key`/`passphrase` unchanged)
- `goreleaser/goreleaser-action` `v3.2.0` → `v7` — the `version: '~> 1.26'` pin is kept on purpose: `.goreleaser.yml` still uses the GoReleaser v1 schema, and the action just installs whatever version is pinned
- `numtide/clean-git-action@v1` replaced with plain `git add -A && git diff --cached --exit-code` — its latest release (v2) still runs on Node 20, so a bump would only postpone the same breakage

CI-only change, so no `VERSION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
