### PR TITLE
[examples] Ensure data region of application matches the correlated source's data region

### DIFF
--- a/docs/resources/errors_application.md
+++ b/docs/resources/errors_application.md
@@ -25,7 +25,6 @@ resource "logtail_errors_application" "configured" {
   name                 = "Production errors (EU)"
   platform             = "ruby_errors"
   application_group_id = logtail_errors_application_group.this.id
-  data_region          = "germany"
   errors_retention     = 90
 
   # Created paused, ingestion will not start unless you flip this
@@ -33,6 +32,7 @@ resource "logtail_errors_application" "configured" {
 
   # Correlate errors with a source's logs and traces (immutable after creation)
   correlate_with_source_id = logtail_collector.production.source_id
+  data_region              = logtail_collector.production.data_region
 
   # Map container stack-trace paths to repo paths for git blame
   code_mapping_stack_root  = "/usr/src/app/"

--- a/examples/resources/logtail_errors_application/resource.tf
+++ b/examples/resources/logtail_errors_application/resource.tf
@@ -10,7 +10,6 @@ resource "logtail_errors_application" "configured" {
   name                 = "Production errors (EU)"
   platform             = "ruby_errors"
   application_group_id = logtail_errors_application_group.this.id
-  data_region          = "germany"
   errors_retention     = 90
 
   # Created paused, ingestion will not start unless you flip this
@@ -18,6 +17,7 @@ resource "logtail_errors_application" "configured" {
 
   # Correlate errors with a source's logs and traces (immutable after creation)
   correlate_with_source_id = logtail_collector.production.source_id
+  data_region              = logtail_collector.production.data_region
 
   # Map container stack-trace paths to repo paths for git blame
   code_mapping_stack_root  = "/usr/src/app/"


### PR DESCRIPTION
Fixes possible drift between data regions by pinning the attribute, avoids hitting 422 on API ([E2E test failed](https://github.com/BetterStackHQ/terraform-provider-logtail/actions/runs/29978539598/job/89149065209)).

```
╷
│ Error: POST https://errors.betterstack.com/api/v1/applications returned 422: {"errors":["Data region must match the correlated source's data region."],"invalid_attributes":["data_region"]}
│ 
│   with logtail_errors_application.configured,
│   on logtail_errors_application__resource.tf line 9, in resource "logtail_errors_application" "configured":
│    9: resource "logtail_errors_application" "configured" {
│ 
╵
```