### PR TITLE
T-19128: Fix logtail_metric import via composite source_id/metric_id ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.12
+VERSION := 10.15.13
 .PHONY: test build
 
 help:

--- a/docs/resources/metric.md
+++ b/docs/resources/metric.md
@@ -3,12 +3,12 @@
 page_title: "logtail_metric Resource - terraform-provider-logtail"
 subcategory: ""
 description: |-
-  This resource allows you to create, update and delete Metrics and Labels.
+  This resource allows you to create, update and delete Metrics and Labels. Import an existing metric using a composite ID in the source_id/metric_id format.
 ---
 
 # logtail_metric (Resource)
 
-This resource allows you to create, update and delete Metrics and Labels.
+This resource allows you to create, update and delete Metrics and Labels. Import an existing metric using a composite ID in the `source_id/metric_id` format.
 
 ## Example Usage
 

--- a/internal/provider/resource_metric.go
+++ b/internal/provider/resource_metric.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -60,9 +61,9 @@ func newMetricResource() *schema.Resource {
 		UpdateContext: metricUpdate,
 		DeleteContext: metricDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: metricImportState,
 		},
-		Description: "This resource allows you to create, update and delete Metrics and Labels.",
+		Description: "This resource allows you to create, update and delete Metrics and Labels. Import an existing metric using a composite ID in the `source_id/metric_id` format.",
 		Schema:      metricSchema,
 	}
 }
@@ -153,7 +154,23 @@ func metricCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 	return metricCopyAttrs(d, &out.Data.Attributes)
 }
 
+// metricImportState accepts a composite source_id/metric_id import ID, mirroring
+// logtail_dashboard_chart / logtail_dashboard_alert - the read needs source_id to
+// build the URL, and an import provides only the ID.
+func metricImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid metric ID format %q, expected 'source_id/metric_id'", d.Id())
+	}
+	if err := d.Set("source_id", parts[0]); err != nil {
+		return nil, err
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
+}
+
 func metricLookup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id := d.Id()
 	d.SetId("")
 	sourceId := d.Get("source_id").(string)
 	fetch := func(page int) (*metricPageHTTPResponse, error) {
@@ -176,6 +193,9 @@ func metricLookup(ctx context.Context, d *schema.ResourceData, meta interface{})
 		var tr metricPageHTTPResponse
 		return &tr, json.Unmarshal(body, &tr)
 	}
+	// The resource always has an ID here (create, update, import), so match on it -
+	// names repeat and are unknown right after an import. The data source has no ID
+	// and looks up by name.
 	name := d.Get("name").(string)
 	page := 1
 	for {
@@ -184,7 +204,7 @@ func metricLookup(ctx context.Context, d *schema.ResourceData, meta interface{})
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.Name == name {
+			if (id != "" && e.ID == id) || (id == "" && *e.Attributes.Name == name) {
 				if d.Id() != "" {
 					return diag.Errorf("duplicate")
 				}

--- a/internal/provider/resource_metric_import_test.go
+++ b/internal/provider/resource_metric_import_test.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceMetricImport(t *testing.T) {
+	var data atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		prefix := "/api/v2/sources/source123/metrics"
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == prefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data.Store(body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"42","attributes":%s}}`, body)))
+		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=1":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":"42","attributes":%s}],"pagination":{"next":null}}`, data.Load())))
+		case r.Method == http.MethodDelete && r.RequestURI == prefix+"/42":
+			w.WriteHeader(http.StatusNoContent)
+			data.Store([]byte(nil))
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	config := `
+	provider "logtail" {
+		api_token = "foo"
+	}
+
+	resource "logtail_metric" "this" {
+		source_id      = "source123"
+		name           = "Test Metric"
+		sql_expression = "JSONExtract(json, 'duration_ms', 'Nullable(Float)')"
+		aggregations   = ["avg"]
+	}
+	`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create.
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_metric.this", "id", "42"),
+					resource.TestCheckResourceAttr("logtail_metric.this", "source_id", "source123"),
+				),
+			},
+			// Step 2 - import using the composite source_id/metric_id ID.
+			{
+				ResourceName:      "logtail_metric.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "source123/42",
+			},
+			// Step 3 - importing a bare metric ID must fail with a helpful message.
+			{
+				ResourceName:  "logtail_metric.this",
+				ImportState:   true,
+				ImportStateId: "42",
+				ExpectError:   regexp.MustCompile(`invalid metric ID format "42", expected 'source_id/metric_id'`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes BetterStackHQ/terraform-provider-logtail#104.

`logtail_metric` used the passthrough importer, but its read builds the URL from `source_id`, which an import never sets — every `terraform import` failed with a 404 on `/api/v2/sources//metrics`.

* The importer now accepts a composite `source_id/metric_id` ID (mirroring `logtail_dashboard_chart` / `logtail_dashboard_alert`) and seeds `source_id` from it.
* `metricLookup` matches by metric ID whenever the resource has one, falling back to the name match only for the data source. Right after an import the name isn't known yet, so the previous name-only match couldn't find the metric even with `source_id` set.

The first commit adds the failing import test; the second makes it pass.