### PR TITLE
T-19130: Read errors application platform from the API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.12
+VERSION := 10.15.13
 .PHONY: test build
 
 help:

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -451,7 +451,7 @@ func errorsApplicationCopyAttrs(d *schema.ResourceData, in *errorsApplication) d
 			// Don't update data region from API if it's already set - data_region can't change
 			continue
 		} else if e.k == "platform" && in.Platform == nil {
-			// An API that predates BetterStackHQ/logtail#16252 omits platform; keep the state value
+			// An API that predates platform being returned omits it; keep the state value
 			continue
 		} else if e.k == "team_id" {
 			if err := SetStringOrIntResourceData(d, "team_id", in.TeamId); err != nil {

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -450,9 +450,6 @@ func errorsApplicationCopyAttrs(d *schema.ResourceData, in *errorsApplication) d
 		if e.k == "data_region" && d.Get("data_region").(string) != "" {
 			// Don't update data region from API if it's already set - data_region can't change
 			continue
-		} else if e.k == "platform" && in.Platform == nil {
-			// An API that predates platform being returned omits it; keep the state value
-			continue
 		} else if e.k == "team_id" {
 			if err := SetStringOrIntResourceData(d, "team_id", in.TeamId); err != nil {
 				derr = append(derr, diag.FromErr(err)[0])

--- a/internal/provider/resource_errors_application.go
+++ b/internal/provider/resource_errors_application.go
@@ -430,12 +430,6 @@ func errorsApplicationCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return err
 	}
 	d.SetId(out.Data.ID)
-	// Ensure platform is set in state since API doesn't return it
-	if platform := d.Get("platform").(string); platform != "" {
-		if err := d.Set("platform", platform); err != nil {
-			return diag.FromErr(err)
-		}
-	}
 	return errorsApplicationCopyAttrs(d, &out.Data.Attributes)
 }
 
@@ -456,8 +450,8 @@ func errorsApplicationCopyAttrs(d *schema.ResourceData, in *errorsApplication) d
 		if e.k == "data_region" && d.Get("data_region").(string) != "" {
 			// Don't update data region from API if it's already set - data_region can't change
 			continue
-		} else if e.k == "platform" && d.Get("platform").(string) != "" {
-			// Don't update platform from API if it's already set - platform can't change and API doesn't return it
+		} else if e.k == "platform" && in.Platform == nil {
+			// An API that predates BetterStackHQ/logtail#16252 omits platform; keep the state value
 			continue
 		} else if e.k == "team_id" {
 			if err := SetStringOrIntResourceData(d, "team_id", in.TeamId); err != nil {

--- a/internal/provider/resource_errors_application_platform_test.go
+++ b/internal/provider/resource_errors_application_platform_test.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// The API returns platform since BetterStackHQ/logtail#16252; the provider must treat
+// it as an ordinary read attribute so refresh and import mirror the remote value.
+func TestResourceErrorsApplicationPlatformFromAPI(t *testing.T) {
+	var data atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		prefix := "/api/v1/applications"
+		id := "1"
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == prefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body = inject(t, body, "token", "generated_by_logtail")
+			body = inject(t, body, "js_tag_token", "js_tag_generated_by_logtail")
+			body = inject(t, body, "ingesting_host", "s1234.us-east-9.betterstackdata.com")
+			body = inject(t, body, "table_name", "test_errors_application")
+			body = inject(t, body, "team_id", 123456)
+			data.Store(body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, body)))
+		case r.Method == http.MethodGet && r.RequestURI == prefix+"/"+id:
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, data.Load().([]byte))))
+		case r.Method == http.MethodDelete && r.RequestURI == prefix+"/"+id:
+			w.WriteHeader(http.StatusNoContent)
+			data.Store([]byte(nil))
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	config := `
+	provider "logtail" {
+		api_token = "foo"
+	}
+
+	resource "logtail_errors_application" "this" {
+		name     = "Test Errors Application"
+		platform = "ruby_errors"
+	}
+	`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create.
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_errors_application.this", "platform", "ruby_errors"),
+				),
+			},
+			// Step 2 - the platform changes out-of-band; refresh must surface the drift
+			// (platform is ForceNew, so the plan proposes a replacement).
+			{
+				PreConfig: func() {
+					data.Store(bytes.Replace(data.Load().([]byte), []byte(`"platform":"ruby_errors"`), []byte(`"platform":"javascript_errors"`), 1))
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_errors_application_platform_test.go
+++ b/internal/provider/resource_errors_application_platform_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// The API returns platform since BetterStackHQ/logtail#16252; the provider must treat
+// A recent API change makes the API return platform; the provider must treat
 // it as an ordinary read attribute so refresh and import mirror the remote value.
 func TestResourceErrorsApplicationPlatformFromAPI(t *testing.T) {
 	var data atomic.Value


### PR DESCRIPTION
Fixes #106.

A recent API change makes the Errors API return `platform`. The provider now reads it back like any other attribute:

- `errorsApplicationCopyAttrs` takes `platform` from the API response, so refresh mirrors the remote value and `terraform import` populates it (previously an import stored `""`, which failed validation and planned a destroy/recreate rotating the ingest token).
- The create-time "ensure platform is set in state" workaround is gone; the create response carries the value.

Assumes the API change is deployed: against an older API that omits `platform`, refresh would read it back as empty and plan a replacement — release this only after the API change ships (the combined E2E run stays red until then).

The first commit adds the failing test (out-of-band platform change must surface in the plan); the follow-ups make it pass and drop the transitional handling. The existing import step covers the import round-trip.
