### PR TITLE
T-18932: Support recovery period Never via recovery_period = -1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.12
+VERSION := 10.15.13
 .PHONY: test build
 
 help:

--- a/docs/data-sources/dashboard_alert.md
+++ b/docs/data-sources/dashboard_alert.md
@@ -59,7 +59,7 @@ output "existing_dashboard_alert_type" {
 - `paused_reason` (String) Read-only field explaining why the alert is paused (e.g., 'Manually paused', complexity issues, too many failures).
 - `push` (Boolean) Enable push notifications.
 - `query_period` (Number) The query evaluation window in seconds.
-- `recovery_period` (Number) The recovery delay in seconds.
+- `recovery_period` (Number) The duration in seconds that a condition must be resolved before an incident is recovered. A value of 0 recovers the alert immediately, a value of -1 means never automatically recover an incident.
 - `series_names` (List of String) Specific series to monitor. Conflicts with series_names_except; set to an empty list to alert on any series.
 - `series_names_except` (List of String) Monitor all series except these. Conflicts with series_names; set to an empty list to alert on any series.
 - `sms` (Boolean) Enable SMS notifications.

--- a/docs/data-sources/exploration_alert.md
+++ b/docs/data-sources/exploration_alert.md
@@ -57,7 +57,7 @@ output "existing_exploration_alert_type" {
 - `paused_reason` (String) Read-only field explaining why the alert is paused (e.g., 'Manually paused', complexity issues, too many failures).
 - `push` (Boolean) Enable push notifications.
 - `query_period` (Number) The query evaluation window in seconds.
-- `recovery_period` (Number) The recovery delay in seconds.
+- `recovery_period` (Number) The duration in seconds that a condition must be resolved before an incident is recovered. A value of 0 recovers the alert immediately, a value of -1 means never automatically recover an incident.
 - `series_names` (List of String) Specific series to monitor. Conflicts with series_names_except; set to an empty list to alert on any series.
 - `series_names_except` (List of String) Monitor all series except these. Conflicts with series_names; set to an empty list to alert on any series.
 - `sms` (Boolean) Enable SMS notifications.

--- a/docs/resources/dashboard_alert.md
+++ b/docs/resources/dashboard_alert.md
@@ -26,6 +26,9 @@ resource "logtail_dashboard_alert" "high_error_rate" {
   query_period        = 300
   confirmation_period = 60
 
+  # Never recover automatically (Never in the UI); omit for the default 60s
+  recovery_period = -1
+
   # What to do when the query returns no data:
   # treat_as_zero / dont_fire / treat_as_previous / start_incident
   on_missing_data = "treat_as_zero"
@@ -139,7 +142,7 @@ resource "logtail_dashboard_alert" "service_down" {
 - `paused` (Boolean) Whether the alert is paused.
 - `push` (Boolean) Enable push notifications.
 - `query_period` (Number) The query evaluation window in seconds.
-- `recovery_period` (Number) The recovery delay in seconds.
+- `recovery_period` (Number) The duration in seconds that a condition must be resolved before an incident is recovered. A value of 0 recovers the alert immediately, a value of -1 means never automatically recover an incident.
 - `series_names` (List of String) Specific series to monitor. Conflicts with series_names_except; set to an empty list to alert on any series.
 - `series_names_except` (List of String) Monitor all series except these. Conflicts with series_names; set to an empty list to alert on any series.
 - `sms` (Boolean) Enable SMS notifications.

--- a/docs/resources/dashboard_alert.md
+++ b/docs/resources/dashboard_alert.md
@@ -26,7 +26,7 @@ resource "logtail_dashboard_alert" "high_error_rate" {
   query_period        = 300
   confirmation_period = 60
 
-  # Never recover automatically (Never in the UI); omit for the default 60s
+  # Never recover automatically
   recovery_period = -1
 
   # What to do when the query returns no data:

--- a/docs/resources/exploration_alert.md
+++ b/docs/resources/exploration_alert.md
@@ -134,7 +134,7 @@ resource "logtail_exploration_alert" "all_http_errors" {
 - `paused` (Boolean) Whether the alert is paused.
 - `push` (Boolean) Enable push notifications.
 - `query_period` (Number) The query evaluation window in seconds.
-- `recovery_period` (Number) The recovery delay in seconds.
+- `recovery_period` (Number) The duration in seconds that a condition must be resolved before an incident is recovered. A value of 0 recovers the alert immediately, a value of -1 means never automatically recover an incident.
 - `series_names` (List of String) Specific series to monitor. Conflicts with series_names_except; set to an empty list to alert on any series.
 - `series_names_except` (List of String) Monitor all series except these. Conflicts with series_names; set to an empty list to alert on any series.
 - `sms` (Boolean) Enable SMS notifications.

--- a/examples/resources/logtail_dashboard_alert/resource.tf
+++ b/examples/resources/logtail_dashboard_alert/resource.tf
@@ -11,7 +11,7 @@ resource "logtail_dashboard_alert" "high_error_rate" {
   query_period        = 300
   confirmation_period = 60
 
-  # Never recover automatically (Never in the UI); omit for the default 60s
+  # Never recover automatically
   recovery_period = -1
 
   # What to do when the query returns no data:

--- a/examples/resources/logtail_dashboard_alert/resource.tf
+++ b/examples/resources/logtail_dashboard_alert/resource.tf
@@ -11,6 +11,9 @@ resource "logtail_dashboard_alert" "high_error_rate" {
   query_period        = 300
   confirmation_period = 60
 
+  # Never recover automatically (Never in the UI); omit for the default 60s
+  recovery_period = -1
+
   # What to do when the query returns no data:
   # treat_as_zero / dont_fire / treat_as_previous / start_incident
   on_missing_data = "treat_as_zero"

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 10.15.12"
+      version = ">= 10.15.13"
     }
   }
 }

--- a/internal/provider/alert_shared.go
+++ b/internal/provider/alert_shared.go
@@ -110,7 +110,7 @@ var alertSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"recovery_period": {
-		Description: "The recovery delay in seconds.",
+		Description: "The duration in seconds that a condition must be resolved before an incident is recovered. A value of 0 recovers the alert immediately, a value of -1 means never automatically recover an incident.",
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Computed:    true,
@@ -412,7 +412,7 @@ type alert struct {
 	StringValue              *string                       `json:"string_value,omitempty"`
 	QueryPeriod              *int                          `json:"query_period,omitempty"`
 	ConfirmationPeriod       *int                          `json:"confirmation_period,omitempty"`
-	RecoveryPeriod           *int                          `json:"recovery_period,omitempty"`
+	RecoveryPeriod           *NullableInt                  `json:"recovery_period,omitempty"`
 	AggregationInterval      *int                          `json:"aggregation_interval,omitempty"`
 	CheckPeriod              *int                          `json:"check_period,omitempty"`
 	SeriesNames              *[]string                     `json:"series_names,omitempty"`
@@ -505,7 +505,7 @@ func loadAlert(d *schema.ResourceData) alert {
 	// Load int fields - use helper to allow 0 values
 	in.QueryPeriod = intFromResourceData(d, "query_period")
 	in.ConfirmationPeriod = intFromResourceData(d, "confirmation_period")
-	in.RecoveryPeriod = intFromResourceData(d, "recovery_period")
+	in.RecoveryPeriod = NullableIntFromResourceData(d, "recovery_period", -1)
 	in.AggregationInterval = intFromResourceData(d, "aggregation_interval")
 	in.CheckPeriod = intFromResourceData(d, "check_period")
 	in.AnomalyTrainingRangeDays = intFromResourceData(d, "anomaly_training_range_days")
@@ -663,10 +663,9 @@ func alertCopyAttrs(d *schema.ResourceData, in *alert) diag.Diagnostics {
 			derr = append(derr, diag.FromErr(err)[0])
 		}
 	}
-	if in.RecoveryPeriod != nil {
-		if err := d.Set("recovery_period", *in.RecoveryPeriod); err != nil {
-			derr = append(derr, diag.FromErr(err)[0])
-		}
+	// The API always returns recovery_period; null is the Never recovery mode, -1 in Terraform
+	if err := SetNullableIntResourceData(d, "recovery_period", -1, in.RecoveryPeriod); err != nil {
+		derr = append(derr, diag.FromErr(err)[0])
 	}
 	if in.AggregationInterval != nil {
 		if err := d.Set("aggregation_interval", *in.AggregationInterval); err != nil {

--- a/internal/provider/resource_dashboard_alert_recovery_test.go
+++ b/internal/provider/resource_dashboard_alert_recovery_test.go
@@ -1,0 +1,185 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// recovery_period contract: an explicit null is the Never mode, which the API stores and
+// serves as null; 0 recovers immediately; an absent key defaults to 60 on create; negative
+// values are rejected. HCL cannot distinguish null from an unset attribute, so Terraform
+// represents Never as -1 and must translate it to null on the wire (and back on read).
+// The mock mirrors the API contract.
+func TestResourceDashboardAlertRecoveryPeriodNever(t *testing.T) {
+	var alertData atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		alertPrefix := "/api/v2/dashboards/1/charts/10/alerts"
+		alertID := "100"
+
+		// Negative values are rejected like the real API; null passes through as Never.
+		// Returns true when the request was rejected.
+		rejectNegativeRecoveryPeriod := func(reqData map[string]interface{}) bool {
+			if v, ok := reqData["recovery_period"]; ok && v != nil {
+				if f, isNum := v.(float64); isNum && f < 0 {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					_, _ = w.Write([]byte(`{"errors":{"recovery_period":["must be greater than or equal to 0"]}}`))
+					return true
+				}
+			}
+			return false
+		}
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == alertPrefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var reqData map[string]interface{}
+			if err := json.Unmarshal(body, &reqData); err != nil {
+				t.Fatal(err)
+			}
+			if rejectNegativeRecoveryPeriod(reqData) {
+				return
+			}
+			if _, ok := reqData["recovery_period"]; !ok {
+				reqData["recovery_period"] = 60
+			}
+			reqData["series_names"] = []string{}
+			reqData["series_names_except"] = []string{}
+			reqData["source_platforms"] = []string{}
+			if _, ok := reqData["on_missing_data"]; !ok {
+				reqData["on_missing_data"] = "treat_as_zero"
+			}
+			if _, ok := reqData["source_mode"]; !ok {
+				reqData["source_mode"] = "source_variable"
+			}
+			if _, ok := reqData["paused"]; !ok {
+				reqData["paused"] = false
+			}
+			respData, _ := json.Marshal(reqData)
+			alertData.Store(respData)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, respData)))
+
+		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/"+alertID:
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))))
+
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var patchReq map[string]interface{}
+			if err = json.Unmarshal(body, &patchReq); err != nil {
+				t.Fatal(err)
+			}
+			if rejectNegativeRecoveryPeriod(patchReq) {
+				return
+			}
+			patch := make(map[string]interface{})
+			if err = json.Unmarshal(alertData.Load().([]byte), &patch); err != nil {
+				t.Fatal(err)
+			}
+			for k, v := range patchReq {
+				patch[k] = v
+			}
+			patched, _ := json.Marshal(patch)
+			alertData.Store(patched)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, patched)))
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	configWithRecoveryPeriod := func(recoveryPeriodLine string) string {
+		return fmt.Sprintf(`
+		provider "logtail" {
+			api_token = "foo"
+		}
+
+		resource "logtail_dashboard_alert" "this" {
+			dashboard_id = "1"
+			chart_id     = "10"
+			name         = "Recovery Period Alert"
+			alert_type   = "threshold"
+			operator     = "higher_than"
+			value        = 100
+			check_period = 300
+			%s
+		}
+		`, recoveryPeriodLine)
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create without recovery_period: the API default of 60 is read back.
+			{
+				Config: configWithRecoveryPeriod(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "recovery_period", "60"),
+				),
+			},
+			// Step 2 - switch to Never (-1 in Terraform, null on the wire).
+			{
+				Config: configWithRecoveryPeriod("recovery_period = -1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "recovery_period", "-1"),
+				),
+			},
+			// Step 3 - no changes, the null read back as -1 must not produce a diff.
+			{
+				Config:   configWithRecoveryPeriod("recovery_period = -1"),
+				PlanOnly: true,
+			},
+			// Step 4 - switch to a regular recovery period.
+			{
+				Config: configWithRecoveryPeriod("recovery_period = 300"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "recovery_period", "300"),
+				),
+			},
+			// Step 5 - and back to Never.
+			{
+				Config: configWithRecoveryPeriod("recovery_period = -1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "recovery_period", "-1"),
+				),
+			},
+			// Step 6 - import reads the null back as -1.
+			{
+				ResourceName:      "logtail_dashboard_alert.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "1/10/100",
+			},
+		},
+	})
+}

--- a/internal/provider/type_nullable_int.go
+++ b/internal/provider/type_nullable_int.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// NullableInt models an integer API field whose null is a meaningful value (e.g. a
+// null recovery_period is the Never recovery mode), represented in Terraform by a
+// sentinel such as -1, since HCL cannot distinguish null from an unset attribute.
+// Ported from terraform-provider-better-uptime, where it backs ssl_expiration and
+// domain_expiration.
+//
+//   - Unset: the field is omitted from JSON (nil *NullableInt with omitempty)
+//   - Set to the sentinel: the field is sent as JSON null (ExplicitNull)
+//   - Set to a value: the field is sent as that value
+type NullableInt struct {
+	Value        *int
+	ExplicitNull bool
+}
+
+func (n NullableInt) MarshalJSON() ([]byte, error) {
+	if n.ExplicitNull {
+		return []byte("null"), nil
+	}
+	return json.Marshal(n.Value)
+}
+
+func (n *NullableInt) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		n.Value = nil
+		n.ExplicitNull = true
+		return nil
+	}
+	var v int
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	n.Value = &v
+	n.ExplicitNull = false
+	return nil
+}
+
+// NullableIntFromResourceData loads a nullable int field from the configuration:
+// nil when the field is not set in config (omit from the request), ExplicitNull when
+// it is set to terraformNullValue, and the value otherwise. Built on
+// intFromResourceData so an explicit 0 is preserved.
+func NullableIntFromResourceData(d *schema.ResourceData, key string, terraformNullValue int) *NullableInt {
+	v := intFromResourceData(d, key)
+	if v == nil {
+		return nil
+	}
+	if *v == terraformNullValue {
+		return &NullableInt{ExplicitNull: true}
+	}
+	return &NullableInt{Value: v}
+}
+
+// SetNullableIntResourceData writes an API value into state, mapping both an omitted
+// field (nil) and an explicit null to terraformNullValue. Only use it for fields the
+// API always returns, where a missing key can't mean anything but null.
+func SetNullableIntResourceData(d *schema.ResourceData, key string, terraformNullValue int, nullableInt *NullableInt) error {
+	if nullableInt == nil || nullableInt.ExplicitNull {
+		return d.Set(key, terraformNullValue)
+	}
+	return d.Set(key, *nullableInt.Value)
+}


### PR DESCRIPTION
Fixes BetterStackHQ/terraform-provider-logtail#97.

Better Stack stores the Never recovery mode as a null `recovery_period`, but the provider modeled the field as `*int` with `omitempty` — there was no way to send an explicit JSON null, so Never couldn't be configured. HCL can't use null directly either: a null attribute is indistinguishable from an unset one, and unset means "unmanaged, keep whatever is configured in the UI".

`recovery_period = -1` is therefore the Terraform representation of Never:

* A `NullableInt` type (ported from terraform-provider-better-uptime's `ssl_expiration`/`domain_expiration` handling) marshals `-1` as JSON null and omits the field when unset; the null the API serves for Never lands in state as `-1`, so refresh, import, and re-plan all converge.
* A value of 0 still recovers immediately, and omitting the attribute keeps the API's 60s default.
* Applies to both `logtail_dashboard_alert` and `logtail_exploration_alert` (shared alert model, same API).

The test mock mirrors the API contract (null = Never, negative values 422, absent defaults to 60 on create) and covers the default, Never, plan convergence, switching back and forth, and import.

Creating an alert as Never additionally depends on an API change that makes create accept the explicit null (update already does). Until it deploys, an alert created with `-1` lands on the 60s default and shows a plan diff, and the combined E2E run (whose dashboard alert example uses `-1`) stays red.