### PR TITLE
Support additional_conditions on dashboard and exploration alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.15.15
+VERSION := 10.16.0
 .PHONY: test build
 
 help:

--- a/docs/data-sources/dashboard_alert.md
+++ b/docs/data-sources/dashboard_alert.md
@@ -37,6 +37,7 @@ output "existing_dashboard_alert_type" {
 
 ### Read-Only
 
+- `additional_conditions` (List of Object) Additional conditions that must all be met together with the main alert condition for the alert to fire (logical AND, evaluated per series on the same time bucket). Up to 4 additional conditions; 'threshold' and 'relative' types only. (see [below for nested schema](#nestedatt--additional_conditions))
 - `aggregation_interval` (Number) The data aggregation interval in seconds.
 - `alert_type` (String) The type of alert: 'threshold', 'relative', or 'anomaly_rrcf'.
 - `anomaly_sensitivity` (Number) Anomaly detection sensitivity 0-100 (only for 'anomaly_rrcf' type, lower = more sensitive).
@@ -69,6 +70,19 @@ output "existing_dashboard_alert_type" {
 - `string_value` (String) The string threshold value (only for threshold alerts with 'equal' or 'not_equal' operators).
 - `updated_at` (String) The time when this alert was updated.
 - `value` (Number) The numeric threshold value. Required for threshold and relative alerts.
+
+<a id="nestedatt--additional_conditions"></a>
+### Nested Schema for `additional_conditions`
+
+Read-Only:
+
+- `alert_type` (String)
+- `operator` (String)
+- `series_names` (List of String)
+- `series_names_except` (List of String)
+- `string_value` (String)
+- `value` (Number)
+
 
 <a id="nestedatt--escalation_target"></a>
 ### Nested Schema for `escalation_target`

--- a/docs/data-sources/exploration_alert.md
+++ b/docs/data-sources/exploration_alert.md
@@ -35,6 +35,7 @@ output "existing_exploration_alert_type" {
 
 ### Read-Only
 
+- `additional_conditions` (List of Object) Additional conditions that must all be met together with the main alert condition for the alert to fire (logical AND, evaluated per series on the same time bucket). Up to 4 additional conditions; 'threshold' and 'relative' types only. (see [below for nested schema](#nestedatt--additional_conditions))
 - `aggregation_interval` (Number) The data aggregation interval in seconds.
 - `alert_type` (String) The type of alert: 'threshold', 'relative', or 'anomaly_rrcf'.
 - `anomaly_sensitivity` (Number) Anomaly detection sensitivity 0-100 (only for 'anomaly_rrcf' type, lower = more sensitive).
@@ -67,6 +68,19 @@ output "existing_exploration_alert_type" {
 - `string_value` (String) The string threshold value (only for threshold alerts with 'equal' or 'not_equal' operators).
 - `updated_at` (String) The time when this alert was updated.
 - `value` (Number) The numeric threshold value. Required for threshold and relative alerts.
+
+<a id="nestedatt--additional_conditions"></a>
+### Nested Schema for `additional_conditions`
+
+Read-Only:
+
+- `alert_type` (String)
+- `operator` (String)
+- `series_names` (List of String)
+- `series_names_except` (List of String)
+- `string_value` (String)
+- `value` (Number)
+
 
 <a id="nestedatt--escalation_target"></a>
 ### Nested Schema for `escalation_target`

--- a/docs/resources/dashboard_alert.md
+++ b/docs/resources/dashboard_alert.md
@@ -33,6 +33,14 @@ resource "logtail_dashboard_alert" "high_error_rate" {
   # treat_as_zero / dont_fire / treat_as_previous / start_incident
   on_missing_data = "treat_as_zero"
 
+  # Fire only when every additional condition holds together with the main
+  # condition (logical AND on the same series and time bucket, up to 4)
+  additional_conditions {
+    alert_type = "threshold"
+    operator   = "lower_than"
+    value      = 10000
+  }
+
   email = true
   push  = true
 }
@@ -124,6 +132,7 @@ resource "logtail_dashboard_alert" "service_down" {
 
 ### Optional
 
+- `additional_conditions` (Block List, Max: 4) Additional conditions that must all be met together with the main alert condition for the alert to fire (logical AND, evaluated per series on the same time bucket). Up to 4 additional conditions; 'threshold' and 'relative' types only. (see [below for nested schema](#nestedblock--additional_conditions))
 - `aggregation_interval` (Number) The data aggregation interval in seconds.
 - `anomaly_sensitivity` (Number) Anomaly detection sensitivity 0-100 (only for 'anomaly_rrcf' type, lower = more sensitive).
 - `anomaly_training_range_days` (Number) How many days of history to train the anomaly detection on, 1-30 (only for 'anomaly_rrcf' type).
@@ -158,6 +167,22 @@ resource "logtail_dashboard_alert" "service_down" {
 - `id` (String) The ID of this alert.
 - `paused_reason` (String) Read-only field explaining why the alert is paused (e.g., 'Manually paused', complexity issues, too many failures).
 - `updated_at` (String) The time when this alert was updated.
+
+<a id="nestedblock--additional_conditions"></a>
+### Nested Schema for `additional_conditions`
+
+Required:
+
+- `alert_type` (String) The type of this condition: 'threshold' or 'relative'. Anomaly detection is only available as the main alert condition.
+- `operator` (String) The comparison operator. For threshold: 'equal', 'not_equal', 'higher_than', 'higher_than_or_equal', 'lower_than', 'lower_than_or_equal'. For relative: 'increases_by', 'decreases_by', 'changes_by'.
+
+Optional:
+
+- `series_names` (List of String) Specific series this condition applies to. Conflicts with series_names_except; omit to apply to any series.
+- `series_names_except` (List of String) Apply this condition to all series except these. Conflicts with series_names; omit to apply to any series.
+- `string_value` (String) The string threshold value of this condition (only with 'equal' or 'not_equal' operators). Set exactly one of value and string_value.
+- `value` (Number) The numeric threshold value of this condition.
+
 
 <a id="nestedblock--escalation_target"></a>
 ### Nested Schema for `escalation_target`

--- a/docs/resources/exploration_alert.md
+++ b/docs/resources/exploration_alert.md
@@ -29,6 +29,14 @@ resource "logtail_exploration_alert" "errors_high" {
   # treat_as_zero / dont_fire / treat_as_previous / start_incident
   on_missing_data = "dont_fire"
 
+  # Fire only when every additional condition holds together with the main
+  # condition (logical AND on the same series and time bucket, up to 4)
+  additional_conditions {
+    alert_type = "threshold"
+    operator   = "lower_than"
+    value      = 10000
+  }
+
   email = true
   push  = true
 }

--- a/docs/resources/exploration_alert.md
+++ b/docs/resources/exploration_alert.md
@@ -116,6 +116,7 @@ resource "logtail_exploration_alert" "all_http_errors" {
 
 ### Optional
 
+- `additional_conditions` (Block List, Max: 4) Additional conditions that must all be met together with the main alert condition for the alert to fire (logical AND, evaluated per series on the same time bucket). Up to 4 additional conditions; 'threshold' and 'relative' types only. (see [below for nested schema](#nestedblock--additional_conditions))
 - `aggregation_interval` (Number) The data aggregation interval in seconds.
 - `anomaly_sensitivity` (Number) Anomaly detection sensitivity 0-100 (only for 'anomaly_rrcf' type, lower = more sensitive).
 - `anomaly_training_range_days` (Number) How many days of history to train the anomaly detection on, 1-30 (only for 'anomaly_rrcf' type).
@@ -150,6 +151,22 @@ resource "logtail_exploration_alert" "all_http_errors" {
 - `id` (String) The ID of this alert.
 - `paused_reason` (String) Read-only field explaining why the alert is paused (e.g., 'Manually paused', complexity issues, too many failures).
 - `updated_at` (String) The time when this alert was updated.
+
+<a id="nestedblock--additional_conditions"></a>
+### Nested Schema for `additional_conditions`
+
+Required:
+
+- `alert_type` (String) The type of this condition: 'threshold' or 'relative'. Anomaly detection is only available as the main alert condition.
+- `operator` (String) The comparison operator. For threshold: 'equal', 'not_equal', 'higher_than', 'higher_than_or_equal', 'lower_than', 'lower_than_or_equal'. For relative: 'increases_by', 'decreases_by', 'changes_by'.
+
+Optional:
+
+- `series_names` (List of String) Specific series this condition applies to. Conflicts with series_names_except; omit to apply to any series.
+- `series_names_except` (List of String) Apply this condition to all series except these. Conflicts with series_names; omit to apply to any series.
+- `string_value` (String) The string threshold value of this condition (only with 'equal' or 'not_equal' operators). Set exactly one of value and string_value.
+- `value` (Number) The numeric threshold value of this condition.
+
 
 <a id="nestedblock--escalation_target"></a>
 ### Nested Schema for `escalation_target`

--- a/examples/resources/logtail_dashboard_alert/resource.tf
+++ b/examples/resources/logtail_dashboard_alert/resource.tf
@@ -18,6 +18,14 @@ resource "logtail_dashboard_alert" "high_error_rate" {
   # treat_as_zero / dont_fire / treat_as_previous / start_incident
   on_missing_data = "treat_as_zero"
 
+  # Fire only when every additional condition holds together with the main
+  # condition (logical AND on the same series and time bucket, up to 4)
+  additional_conditions {
+    alert_type = "threshold"
+    operator   = "lower_than"
+    value      = 10000
+  }
+
   email = true
   push  = true
 }

--- a/examples/resources/logtail_exploration_alert/resource.tf
+++ b/examples/resources/logtail_exploration_alert/resource.tf
@@ -14,6 +14,14 @@ resource "logtail_exploration_alert" "errors_high" {
   # treat_as_zero / dont_fire / treat_as_previous / start_incident
   on_missing_data = "dont_fire"
 
+  # Fire only when every additional condition holds together with the main
+  # condition (logical AND on the same series and time bucket, up to 4)
+  additional_conditions {
+    alert_type = "threshold"
+    operator   = "lower_than"
+    value      = 10000
+  }
+
   email = true
   push  = true
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     logtail = {
       source  = "BetterStackHQ/logtail"
-      version = ">= 10.15.15"
+      version = ">= 10.16.0"
     }
   }
 }

--- a/internal/provider/alert_shared.go
+++ b/internal/provider/alert_shared.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -33,7 +34,8 @@ func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) 
 		!diff.HasChange("operator") &&
 		!diff.HasChange("check_period") &&
 		!diff.HasChange("on_missing_data") &&
-		!diff.HasChange("anomaly_training_range_days") {
+		!diff.HasChange("anomaly_training_range_days") &&
+		!diff.HasChange("additional_conditions") {
 		return nil
 	}
 	alertType := diff.Get("alert_type").(string)
@@ -53,6 +55,22 @@ func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) 
 		}
 		if alertType != "anomaly_rrcf" && !raw.GetAttr("anomaly_training_range_days").IsNull() {
 			return fmt.Errorf("anomaly_training_range_days is only supported for anomaly_rrcf alerts")
+		}
+	}
+	// The nested condition objects normalize the pair server-side by silently
+	// preferring series_names_except; reject the ambiguity here instead
+	// (ConflictsWith cannot reference attributes inside a list element).
+	if raw := diff.GetRawConfig(); !raw.IsNull() {
+		conds := raw.GetAttr("additional_conditions")
+		if !conds.IsNull() {
+			for it := conds.ElementIterator(); it.Next(); {
+				_, el := it.Element()
+				names := el.GetAttr("series_names")
+				except := el.GetAttr("series_names_except")
+				if !names.IsNull() && names.LengthInt() > 0 && !except.IsNull() && except.LengthInt() > 0 {
+					return fmt.Errorf("an additional condition cannot set both series_names and series_names_except")
+				}
+			}
 		}
 	}
 	return nil
@@ -149,6 +167,50 @@ var alertSchema = map[string]*schema.Schema{
 		Computed:      true,
 		Elem:          &schema.Schema{Type: schema.TypeString},
 		ConflictsWith: []string{"series_names"},
+	},
+	"additional_conditions": {
+		Description: "Additional conditions that must all be met together with the main alert condition for the alert to fire (logical AND, evaluated per series on the same time bucket). Up to 4 additional conditions; 'threshold' and 'relative' types only.",
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    4,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"alert_type": {
+					Description:  "The type of this condition: 'threshold' or 'relative'. Anomaly detection is only available as the main alert condition.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"threshold", "relative"}, false),
+				},
+				"operator": {
+					Description:  "The comparison operator. For threshold: 'equal', 'not_equal', 'higher_than', 'higher_than_or_equal', 'lower_than', 'lower_than_or_equal'. For relative: 'increases_by', 'decreases_by', 'changes_by'.",
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"equal", "not_equal", "higher_than", "higher_than_or_equal", "lower_than", "lower_than_or_equal", "increases_by", "decreases_by", "changes_by"}, false),
+				},
+				"value": {
+					Description: "The numeric threshold value of this condition.",
+					Type:        schema.TypeFloat,
+					Optional:    true,
+				},
+				"string_value": {
+					Description: "The string threshold value of this condition (only with 'equal' or 'not_equal' operators). Set exactly one of value and string_value.",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
+				"series_names": {
+					Description: "Specific series this condition applies to. Conflicts with series_names_except; omit to apply to any series.",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+				"series_names_except": {
+					Description: "Apply this condition to all series except these. Conflicts with series_names; omit to apply to any series.",
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
 	},
 	"on_missing_data": {
 		Description:  "What to do when the monitored query returns no data: 'treat_as_zero', 'dont_fire', 'treat_as_previous', or 'start_incident'. Only for threshold and relative alerts.",
@@ -433,6 +495,7 @@ type alert struct {
 	AnomalySensitivity       *float64                      `json:"anomaly_sensitivity,omitempty"`
 	AnomalyTrigger           *string                       `json:"anomaly_trigger,omitempty"`
 	AnomalyTrainingRangeDays *int                          `json:"anomaly_training_range_days,omitempty"`
+	AdditionalConditions     *[]alertCondition             `json:"additional_conditions,omitempty"`
 	EscalationTarget         alertEscalationTargetWrapper  `json:"escalation_target,omitempty"`
 	Metadata                 map[string]alertMetadataValue `json:"metadata,omitempty"`
 	CreatedAt                *string                       `json:"created_at,omitempty"`
@@ -444,6 +507,62 @@ type alertHTTPResponse struct {
 		ID         string `json:"id"`
 		Attributes alert  `json:"attributes"`
 	} `json:"data"`
+}
+
+// alertCondition is one additional alert condition; the main condition lives
+// in the alert's own alert_type/operator/value fields.
+type alertCondition struct {
+	AlertType         *string   `json:"alert_type,omitempty"`
+	Operator          *string   `json:"operator,omitempty"`
+	Value             *float64  `json:"value,omitempty"`
+	StringValue       *string   `json:"string_value,omitempty"`
+	SeriesNames       *[]string `json:"series_names,omitempty"`
+	SeriesNamesExcept *[]string `json:"series_names_except,omitempty"`
+}
+
+// conditionsFromRawConfig converts the raw config list of additional_conditions
+// into wire objects, keeping attributes the user never wrote out of the payload.
+func conditionsFromRawConfig(list cty.Value) *[]alertCondition {
+	out := []alertCondition{}
+	for it := list.ElementIterator(); it.Next(); {
+		_, el := it.Element()
+		var c alertCondition
+		if v := el.GetAttr("alert_type"); !v.IsNull() {
+			s := v.AsString()
+			c.AlertType = &s
+		}
+		if v := el.GetAttr("operator"); !v.IsNull() {
+			s := v.AsString()
+			c.Operator = &s
+		}
+		if v := el.GetAttr("value"); !v.IsNull() {
+			f, _ := v.AsBigFloat().Float64()
+			c.Value = &f
+		}
+		if v := el.GetAttr("string_value"); !v.IsNull() && v.AsString() != "" {
+			s := v.AsString()
+			c.StringValue = &s
+		}
+		if v := el.GetAttr("series_names"); !v.IsNull() && v.LengthInt() > 0 {
+			c.SeriesNames = ctyStringList(v)
+		}
+		if v := el.GetAttr("series_names_except"); !v.IsNull() && v.LengthInt() > 0 {
+			c.SeriesNamesExcept = ctyStringList(v)
+		}
+		out = append(out, c)
+	}
+	return &out
+}
+
+func ctyStringList(list cty.Value) *[]string {
+	names := make([]string, 0, list.LengthInt())
+	for it := list.ElementIterator(); it.Next(); {
+		_, el := it.Element()
+		if !el.IsNull() {
+			names = append(names, el.AsString())
+		}
+	}
+	return &names
 }
 
 func stringListFromResourceData(d *schema.ResourceData, key string) *[]string {
@@ -528,6 +647,15 @@ func loadAlert(d *schema.ResourceData) alert {
 		}
 		if !raw.GetAttr("series_names_except").IsNull() {
 			in.SeriesNamesExcept = stringListFromResourceData(d, "series_names_except")
+		}
+	}
+
+	// additional_conditions reads the raw config so unset fields (value vs
+	// string_value) stay off the wire. An empty block list sends [], which the
+	// API takes as "clear all conditions" (an absent key leaves them untouched).
+	if raw := d.GetRawConfig(); !raw.IsNull() {
+		if conds := raw.GetAttr("additional_conditions"); !conds.IsNull() {
+			in.AdditionalConditions = conditionsFromRawConfig(conds)
 		}
 	}
 	if v, ok := d.GetOk("source_platforms"); ok {
@@ -738,6 +866,34 @@ func alertCopyAttrs(d *schema.ResourceData, in *alert) diag.Diagnostics {
 	}
 	if in.SourcePlatforms != nil {
 		if err := d.Set("source_platforms", in.SourcePlatforms); err != nil {
+			derr = append(derr, diag.FromErr(err)[0])
+		}
+	}
+	if in.AdditionalConditions != nil {
+		conds := make([]interface{}, 0, len(*in.AdditionalConditions))
+		for _, c := range *in.AdditionalConditions {
+			item := map[string]interface{}{}
+			if c.AlertType != nil {
+				item["alert_type"] = *c.AlertType
+			}
+			if c.Operator != nil {
+				item["operator"] = *c.Operator
+			}
+			if c.Value != nil {
+				item["value"] = *c.Value
+			}
+			if c.StringValue != nil {
+				item["string_value"] = *c.StringValue
+			}
+			if c.SeriesNames != nil {
+				item["series_names"] = *c.SeriesNames
+			}
+			if c.SeriesNamesExcept != nil {
+				item["series_names_except"] = *c.SeriesNamesExcept
+			}
+			conds = append(conds, item)
+		}
+		if err := d.Set("additional_conditions", conds); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}
 	}

--- a/internal/provider/resource_dashboard_alert_conditions_test.go
+++ b/internal/provider/resource_dashboard_alert_conditions_test.go
@@ -1,0 +1,241 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// additional_conditions contract: the array holds conditions 2..5 combined with the main
+// condition by logical AND; each object carries only the attributes the user set (a string
+// condition must not leak "value": 0), while the API echoes every condition normalized to
+// all six keys with nulls and empty arrays. Sending [] clears all conditions; an absent key
+// leaves them untouched, so removing every block must still send []. The mock mirrors that.
+func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
+	var alertData atomic.Value
+
+	// normalizeConditions mirrors ChartAlert::Condition#to_h: all six keys, wire nulls.
+	normalizeConditions := func(reqData map[string]interface{}) {
+		raw, ok := reqData["additional_conditions"].([]interface{})
+		if !ok {
+			return
+		}
+		for i, item := range raw {
+			cond, ok := item.(map[string]interface{})
+			if !ok {
+				t.Fatalf("condition %d is not an object: %v", i, item)
+			}
+			for _, key := range []string{"alert_type", "operator", "value", "string_value"} {
+				if _, ok := cond[key]; !ok {
+					cond[key] = nil
+				}
+			}
+			for _, key := range []string{"series_names", "series_names_except"} {
+				if _, ok := cond[key]; !ok {
+					cond[key] = []string{}
+				}
+			}
+		}
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		alertPrefix := "/api/v2/dashboards/1/charts/10/alerts"
+		alertID := "100"
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == alertPrefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var reqData map[string]interface{}
+			if err := json.Unmarshal(body, &reqData); err != nil {
+				t.Fatal(err)
+			}
+			// The string condition set no numeric value; a leaked zero would flip the
+			// API into numeric comparison, so the wire shape is asserted exactly.
+			conds, ok := reqData["additional_conditions"].([]interface{})
+			if !ok || len(conds) != 1 {
+				t.Fatalf("expected exactly one additional condition, got %v", reqData["additional_conditions"])
+			}
+			cond := conds[0].(map[string]interface{})
+			if len(cond) != 3 || cond["alert_type"] != "threshold" || cond["operator"] != "lower_than" || cond["value"] != float64(10000) {
+				t.Fatalf("unexpected condition payload: %v", cond)
+			}
+			normalizeConditions(reqData)
+			reqData["series_names"] = []string{}
+			reqData["series_names_except"] = []string{}
+			reqData["source_platforms"] = []string{}
+			if _, ok := reqData["on_missing_data"]; !ok {
+				reqData["on_missing_data"] = "treat_as_zero"
+			}
+			if _, ok := reqData["source_mode"]; !ok {
+				reqData["source_mode"] = "source_variable"
+			}
+			if _, ok := reqData["paused"]; !ok {
+				reqData["paused"] = false
+			}
+			if _, ok := reqData["recovery_period"]; !ok {
+				reqData["recovery_period"] = 60
+			}
+			respData, _ := json.Marshal(reqData)
+			alertData.Store(respData)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, respData)))
+
+		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/"+alertID:
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))))
+
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var patchReq map[string]interface{}
+			if err = json.Unmarshal(body, &patchReq); err != nil {
+				t.Fatal(err)
+			}
+			normalizeConditions(patchReq)
+			patch := make(map[string]interface{})
+			if err = json.Unmarshal(alertData.Load().([]byte), &patch); err != nil {
+				t.Fatal(err)
+			}
+			for k, v := range patchReq {
+				patch[k] = v
+			}
+			patched, _ := json.Marshal(patch)
+			alertData.Store(patched)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, patched)))
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	configWithConditions := func(conditionBlocks string) string {
+		return fmt.Sprintf(`
+		provider "logtail" {
+			api_token = "foo"
+		}
+
+		resource "logtail_dashboard_alert" "this" {
+			dashboard_id = "1"
+			chart_id     = "10"
+			name         = "Band Alert"
+			alert_type   = "threshold"
+			operator     = "higher_than"
+			value        = 100
+			check_period = 300
+			%s
+		}
+		`, conditionBlocks)
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create with one extra condition (a band alert: > 100 and < 10000).
+			{
+				Config: configWithConditions(`
+					additional_conditions {
+						alert_type = "threshold"
+						operator   = "lower_than"
+						value      = 10000
+					}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.#", "1"),
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.0.alert_type", "threshold"),
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.0.operator", "lower_than"),
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.0.value", "10000"),
+				),
+			},
+			// Step 2 - the normalized echo (null string_value, empty series arrays) is not drift.
+			{
+				Config: configWithConditions(`
+					additional_conditions {
+						alert_type = "threshold"
+						operator   = "lower_than"
+						value      = 10000
+					}
+				`),
+				PlanOnly: true,
+			},
+			// Step 3 - grow to two conditions, the second scoped to specific series.
+			{
+				Config: configWithConditions(`
+					additional_conditions {
+						alert_type = "threshold"
+						operator   = "lower_than"
+						value      = 10000
+					}
+					additional_conditions {
+						alert_type   = "relative"
+						operator     = "increases_by"
+						value        = 50
+						series_names = ["production"]
+					}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.#", "2"),
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.1.alert_type", "relative"),
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.1.series_names.0", "production"),
+				),
+			},
+			// Step 4 - import round-trips the normalized conditions.
+			{
+				ResourceName:      "logtail_dashboard_alert.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "1/10/100",
+			},
+			// Step 5 - removing every block clears the conditions ([] on the wire;
+			// an absent key would leave them untouched server-side).
+			{
+				Config: configWithConditions(""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.#", "0"),
+				),
+			},
+			// Step 6 - both series scopes in one condition are rejected in the plan
+			// (the API would silently keep only series_names_except).
+			{
+				PlanOnly: true,
+				Config: configWithConditions(`
+					additional_conditions {
+						alert_type          = "threshold"
+						operator            = "lower_than"
+						value               = 10000
+						series_names        = ["production"]
+						series_names_except = ["staging"]
+					}
+				`),
+				ExpectError: regexp.MustCompile("cannot set both series_names and series_names_except"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds the `additional_conditions` block to `logtail_dashboard_alert` and `logtail_exploration_alert` (shared alert schema), covering the multiple-conditions alert capability: up to 4 extra `threshold`/`relative` conditions combined with the main condition by logical AND, each with its own `operator`, `value`/`string_value`, and optional `series_names`/`series_names_except` scope.

## Implementation notes

- Conditions are parsed from the **raw config** so attributes the user never wrote stay off the wire (a string condition must not leak `"value": 0`, which would flip the API into numeric comparison).
- Removing every block sends `[]`, which the API takes as "clear all conditions" (an absent key leaves them untouched server-side).
- The API silently prefers `series_names_except` when a condition sets both scope fields; the provider rejects that combination at plan time instead (`ConflictsWith` can't reference attributes inside a list element).
- Data sources pick the field up automatically via the computed-schema conversion; docs regenerated with `make gen`.
- `VERSION` bumped to 10.16.0 (new capability), `examples/versions.tf` raised to match.

## Rollout dependency

Creating an alert with a non-empty `additional_conditions` array is currently rejected by the API (`422 additional_conditions are not enabled`) until the server-side rollout gate is enabled, so the `e2e_combined` job will stay red until then. Merge/tag after the gate flips.

## Testing

- `TestResourceDashboardAlertAdditionalConditions`: exact wire-shape assertion on create, normalized-echo drift check (`PlanOnly`), grow to two conditions, import round-trip, clear-on-removal, and the both-scopes plan-time rejection, against a mock that normalizes conditions like `ChartAlert::Condition#to_h`.
- Full unit suite: 106 passed.
- Extended the `logtail_dashboard_alert` example (E2E coverage once the gate is enabled).