### PR TITLE
Fix panic when reading the logtail_connection data source

### DIFF
--- a/internal/provider/data_connection_test.go
+++ b/internal/provider/data_connection_test.go
@@ -1,0 +1,80 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestDataSourceConnection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		switch {
+		case r.Method == http.MethodGet && r.RequestURI == "/api/v1/connections/1":
+			// The API returns `password`, but the data source schema has no such
+			// attribute - the shared connectionCopyAttrs must skip it, not panic.
+			_, _ = w.Write([]byte(`{"data":{"id":"1","attributes":{
+				"client_type":"clickhouse",
+				"team_names":["Test Team"],
+				"data_region":"us_east",
+				"host":"us-east-9-connect.betterstackdata.com",
+				"port":443,
+				"username":"u3PM1B7BEJgqHXBymIpnfCAs3K02XIZaE",
+				"password":"XNFT7RaKtjCyZiQIeR782kykeAxOa4U1eLaKxyd7KDN58xlgCwZ0wEkr7YdoBvXh",
+				"created_at":"2025-11-26T14:00:00.000Z",
+				"sample_query":"curl command example",
+				"data_sources":[]
+			}}}`))
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - lookup by ID.
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				data "logtail_connection" "this" {
+					id = "1"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "id", "1"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "client_type", "clickhouse"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "team_names.#", "1"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "team_names.0", "Test Team"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "data_region", "us_east"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "host", "us-east-9-connect.betterstackdata.com"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "port", "443"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "username", "u3PM1B7BEJgqHXBymIpnfCAs3K02XIZaE"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "created_at", "2025-11-26T14:00:00.000Z"),
+					resource.TestCheckResourceAttr("data.logtail_connection.this", "sample_query", "curl command example"),
+					resource.TestCheckNoResourceAttr("data.logtail_connection.this", "password"),
+				),
+				PreConfig: func() {
+					t.Log("step 1 - lookup by ID")
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/resource_connection.go
+++ b/internal/provider/resource_connection.go
@@ -273,13 +273,20 @@ func connectionDelete(ctx context.Context, d *schema.ResourceData, meta interfac
 func connectionCopyAttrs(d *schema.ResourceData, in *connection) diag.Diagnostics {
 	var derr diag.Diagnostics
 	for _, e := range connectionRef(in) {
-		if e.k == "password" && d.Get("password").(string) != "" {
+		// This is shared with the data source, whose schema omits `password`. d.Get
+		// returns an untyped nil for an attribute the schema doesn't declare (a set
+		// one always yields at least its zero value), so skip those outright.
+		current := d.Get(e.k)
+		if current == nil {
+			continue
+		}
+		if e.k == "password" && current.(string) != "" {
 			// Don't update password from API if it's already set - password is only returned during creation
 			continue
-		} else if e.k == "data_region" && d.Get("data_region").(string) != "" {
+		} else if e.k == "data_region" && current.(string) != "" {
 			// Preserve user-specified data_region over API-normalized value
 			continue
-		} else if e.k == "valid_until" && d.Get("valid_until").(string) != "" {
+		} else if e.k == "valid_until" && current.(string) != "" {
 			// Preserve user-specified valid_until over API-formatted value
 			continue
 		} else if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {


### PR DESCRIPTION
Closes #129.

`connectionCopyAttrs` is shared between the `logtail_connection` resource and the data source, but the data-source schema declares no `password` attribute. `d.Get` returns an untyped `nil` for an attribute the schema does not declare, so the `.(string)` assertion panicked on every successful data-source read, in every version since the data source was added, through `10.17.0`.

The fix skips attributes that are missing from the schema: a declared attribute always yields at least its zero value, so a `nil` means "not in this schema".

Adds `internal/provider/data_connection_test.go`, which reproduces the panic without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)