### PR TITLE
Fix plan-time panic on unknown additional_conditions values

### DIFF
--- a/internal/provider/alert_shared.go
+++ b/internal/provider/alert_shared.go
@@ -16,7 +16,7 @@ func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) 
 	// The API treats series_names / series_names_except as one setting: writing either one
 	// clears the other. Mirror that in the plan, so switching between the two fields - or
 	// explicitly emptying the configured one - plans the update that resets the sibling.
-	if raw := diff.GetRawConfig(); !raw.IsNull() && diff.Id() != "" {
+	if raw := diff.GetRawConfig(); !raw.IsNull() && raw.IsKnown() && diff.Id() != "" {
 		if !raw.GetAttr("series_names").IsNull() {
 			if err := diff.SetNew("series_names_except", []interface{}{}); err != nil {
 				return err
@@ -49,7 +49,7 @@ func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) 
 	}
 	// Both fields are Computed, so state carries API-returned values; only what
 	// is literally set in the configuration should fail the type check.
-	if raw := diff.GetRawConfig(); !raw.IsNull() {
+	if raw := diff.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
 		if alertType == "anomaly_rrcf" && !raw.GetAttr("on_missing_data").IsNull() {
 			return fmt.Errorf("on_missing_data is only supported for threshold and relative alerts")
 		}
@@ -60,14 +60,23 @@ func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) 
 	// The nested condition objects normalize the pair server-side by silently
 	// preferring series_names_except; reject the ambiguity here instead
 	// (ConflictsWith cannot reference attributes inside a list element).
-	if raw := diff.GetRawConfig(); !raw.IsNull() {
+	// Values still unknown at plan time - a list derived from a resource that has not
+	// been applied yet - are skipped: cty panics on ElementIterator and LengthInt for
+	// those, and there is nothing to compare until apply.
+	if raw := diff.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
 		conds := raw.GetAttr("additional_conditions")
-		if !conds.IsNull() {
+		if !conds.IsNull() && conds.IsKnown() {
 			for it := conds.ElementIterator(); it.Next(); {
 				_, el := it.Element()
+				if !el.IsKnown() {
+					continue
+				}
 				names := el.GetAttr("series_names")
 				except := el.GetAttr("series_names_except")
-				if !names.IsNull() && names.LengthInt() > 0 && !except.IsNull() && except.LengthInt() > 0 {
+				if names.IsNull() || !names.IsKnown() || except.IsNull() || !except.IsKnown() {
+					continue
+				}
+				if names.LengthInt() > 0 && except.LengthInt() > 0 {
 					return fmt.Errorf("an additional condition cannot set both series_names and series_names_except")
 				}
 			}

--- a/internal/provider/alert_shared.go
+++ b/internal/provider/alert_shared.go
@@ -13,10 +13,17 @@ import (
 )
 
 func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	// Values still unknown at plan time - a list derived from a resource that has not been
+	// applied yet - are skipped throughout: cty panics on ElementIterator and LengthInt for
+	// those, and there is nothing to compare until the plan runs again at apply time with
+	// everything known.
+	raw := diff.GetRawConfig()
+	rawUsable := !raw.IsNull() && raw.IsKnown()
+
 	// The API treats series_names / series_names_except as one setting: writing either one
 	// clears the other. Mirror that in the plan, so switching between the two fields - or
 	// explicitly emptying the configured one - plans the update that resets the sibling.
-	if raw := diff.GetRawConfig(); !raw.IsNull() && raw.IsKnown() && diff.Id() != "" {
+	if rawUsable && diff.Id() != "" {
 		if !raw.GetAttr("series_names").IsNull() {
 			if err := diff.SetNew("series_names_except", []interface{}{}); err != nil {
 				return err
@@ -47,23 +54,19 @@ func validateAlert(_ context.Context, diff *schema.ResourceDiff, _ interface{}) 
 			return fmt.Errorf("check_period is required for %s alerts", alertType)
 		}
 	}
-	// Both fields are Computed, so state carries API-returned values; only what
-	// is literally set in the configuration should fail the type check.
-	if raw := diff.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
+	if rawUsable {
+		// Both fields are Computed, so state carries API-returned values; only what
+		// is literally set in the configuration should fail the type check.
 		if alertType == "anomaly_rrcf" && !raw.GetAttr("on_missing_data").IsNull() {
 			return fmt.Errorf("on_missing_data is only supported for threshold and relative alerts")
 		}
 		if alertType != "anomaly_rrcf" && !raw.GetAttr("anomaly_training_range_days").IsNull() {
 			return fmt.Errorf("anomaly_training_range_days is only supported for anomaly_rrcf alerts")
 		}
-	}
-	// The nested condition objects normalize the pair server-side by silently
-	// preferring series_names_except; reject the ambiguity here instead
-	// (ConflictsWith cannot reference attributes inside a list element).
-	// Values still unknown at plan time - a list derived from a resource that has not
-	// been applied yet - are skipped: cty panics on ElementIterator and LengthInt for
-	// those, and there is nothing to compare until apply.
-	if raw := diff.GetRawConfig(); !raw.IsNull() && raw.IsKnown() {
+
+		// The nested condition objects normalize the pair server-side by silently
+		// preferring series_names_except; reject the ambiguity here instead
+		// (ConflictsWith cannot reference attributes inside a list element).
 		conds := raw.GetAttr("additional_conditions")
 		if !conds.IsNull() && conds.IsKnown() {
 			for it := conds.ElementIterator(); it.Next(); {

--- a/internal/provider/resource_dashboard_alert_conditions_test.go
+++ b/internal/provider/resource_dashboard_alert_conditions_test.go
@@ -96,10 +96,10 @@ func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 			respData, _ := json.Marshal(reqData)
 			alertData.Store(respData)
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, respData)))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, alertID, respData)
 
 		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/"+alertID:
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))
 
 		case r.Method == http.MethodPatch && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
 			body, err := io.ReadAll(r.Body)
@@ -120,7 +120,7 @@ func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 			}
 			patched, _ := json.Marshal(patch)
 			alertData.Store(patched)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, patched)))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, alertID, patched)
 
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
 			w.WriteHeader(http.StatusNoContent)
@@ -287,9 +287,9 @@ func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
 			}
 			groupData.Store(body)
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, groupID, body)))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, groupID, body)
 		case r.Method == http.MethodGet && r.RequestURI == groupPrefix+"/"+groupID:
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, groupID, groupData.Load().([]byte))))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, groupID, groupData.Load().([]byte))
 		case r.Method == http.MethodDelete && r.RequestURI == groupPrefix+"/"+groupID:
 			w.WriteHeader(http.StatusNoContent)
 			groupData.Store([]byte(nil))
@@ -302,9 +302,9 @@ func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
 			body = normalizeAlert(body)
 			alertData.Store(body)
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, body)))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, alertID, body)
 		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/"+alertID:
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))))
+			_, _ = fmt.Fprintf(w, `{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))
 		case r.Method == http.MethodDelete && r.RequestURI == alertPrefix+"/"+alertID:
 			w.WriteHeader(http.StatusNoContent)
 			alertData.Store([]byte(nil))

--- a/internal/provider/resource_dashboard_alert_conditions_test.go
+++ b/internal/provider/resource_dashboard_alert_conditions_test.go
@@ -16,10 +16,17 @@ import (
 )
 
 // normalizeConditions mirrors ChartAlert::Condition#to_h: all six keys, wire nulls.
+// A request that omits additional_conditions entirely leaves the stored conditions
+// untouched server-side, so there is nothing to normalize; anything other than an
+// array under that key is a provider bug and fails the test.
 func normalizeConditions(t *testing.T, reqData map[string]interface{}) {
-	raw, ok := reqData["additional_conditions"].([]interface{})
-	if !ok {
+	value, present := reqData["additional_conditions"]
+	if !present {
 		return
+	}
+	raw, ok := value.([]interface{})
+	if !ok {
+		t.Fatalf("additional_conditions is not an array: %#v", value)
 	}
 	for i, item := range raw {
 		cond, ok := item.(map[string]interface{})

--- a/internal/provider/resource_dashboard_alert_conditions_test.go
+++ b/internal/provider/resource_dashboard_alert_conditions_test.go
@@ -239,3 +239,129 @@ func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 		},
 	})
 }
+
+// A condition's series_names may reference an attribute of a resource that has not
+// been created yet, so the raw config carries an unknown value at plan time. cty
+// panics on ElementIterator/LengthInt for those, so validateAlert must skip them.
+func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
+	var alertData atomic.Value
+
+	// The API echoes every alert normalized to all keys; mirror enough of that so
+	// the post-apply plan is empty and the test fails only on the panic.
+	normalizeAlert := func(body []byte) []byte {
+		var attrs map[string]interface{}
+		if err := json.Unmarshal(body, &attrs); err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"series_names", "series_names_except", "source_platforms"} {
+			if _, ok := attrs[key]; !ok {
+				attrs[key] = []string{}
+			}
+		}
+		for _, item := range attrs["additional_conditions"].([]interface{}) {
+			cond := item.(map[string]interface{})
+			for _, key := range []string{"alert_type", "operator", "value", "string_value"} {
+				if _, ok := cond[key]; !ok {
+					cond[key] = nil
+				}
+			}
+			for _, key := range []string{"series_names", "series_names_except"} {
+				if _, ok := cond[key]; !ok {
+					cond[key] = []string{}
+				}
+			}
+		}
+		out, err := json.Marshal(attrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("Received " + r.Method + " " + r.RequestURI)
+
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+
+		alertPrefix := "/api/v2/dashboards/1/charts/10/alerts"
+
+		switch {
+		case r.Method == http.MethodPost && r.RequestURI == "/api/v1/source-groups":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"7","attributes":%s}}`, body)))
+		case r.Method == http.MethodGet && r.RequestURI == "/api/v1/source-groups/7":
+			_, _ = w.Write([]byte(`{"data":{"id":"7","attributes":{"name":"Unknown series group"}}}`))
+		case r.Method == http.MethodDelete && r.RequestURI == "/api/v1/source-groups/7":
+			w.WriteHeader(http.StatusNoContent)
+
+		case r.Method == http.MethodPost && r.RequestURI == alertPrefix:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body = normalizeAlert(body)
+			alertData.Store(body)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"100","attributes":%s}}`, body)))
+		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/100":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"100","attributes":%s}}`, alertData.Load().([]byte))))
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"logtail": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				provider "logtail" {
+					api_token = "foo"
+				}
+
+				resource "logtail_source_group" "this" {
+					name = "Unknown series group"
+				}
+
+				resource "logtail_dashboard_alert" "this" {
+					dashboard_id = "1"
+					chart_id     = "10"
+					name         = "Unknown series"
+					alert_type   = "threshold"
+					operator     = "higher_than"
+					value        = 100
+					check_period = 300
+
+					additional_conditions {
+						alert_type   = "threshold"
+						operator     = "lower_than"
+						value        = 10000
+						# Branches of differing length keep the whole list unknown at plan time
+						# (a same-length conditional would only leave the element unknown).
+						series_names = logtail_source_group.this.id == "7" ? ["production"] : ["production", "staging"]
+					}
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.#", "1"),
+					resource.TestCheckResourceAttr("logtail_dashboard_alert.this", "additional_conditions.0.series_names.0", "production"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_dashboard_alert_conditions_test.go
+++ b/internal/provider/resource_dashboard_alert_conditions_test.go
@@ -15,6 +15,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// normalizeConditions mirrors ChartAlert::Condition#to_h: all six keys, wire nulls.
+func normalizeConditions(t *testing.T, reqData map[string]interface{}) {
+	raw, ok := reqData["additional_conditions"].([]interface{})
+	if !ok {
+		return
+	}
+	for i, item := range raw {
+		cond, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("condition %d is not an object: %v", i, item)
+		}
+		for _, key := range []string{"alert_type", "operator", "value", "string_value"} {
+			if _, ok := cond[key]; !ok {
+				cond[key] = nil
+			}
+		}
+		for _, key := range []string{"series_names", "series_names_except"} {
+			if _, ok := cond[key]; !ok {
+				cond[key] = []string{}
+			}
+		}
+	}
+}
+
 // additional_conditions contract: the array holds conditions 2..5 combined with the main
 // condition by logical AND; each object carries only the attributes the user set (a string
 // condition must not leak "value": 0), while the API echoes every condition normalized to
@@ -22,30 +46,6 @@ import (
 // leaves them untouched, so removing every block must still send []. The mock mirrors that.
 func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 	var alertData atomic.Value
-
-	// normalizeConditions mirrors ChartAlert::Condition#to_h: all six keys, wire nulls.
-	normalizeConditions := func(reqData map[string]interface{}) {
-		raw, ok := reqData["additional_conditions"].([]interface{})
-		if !ok {
-			return
-		}
-		for i, item := range raw {
-			cond, ok := item.(map[string]interface{})
-			if !ok {
-				t.Fatalf("condition %d is not an object: %v", i, item)
-			}
-			for _, key := range []string{"alert_type", "operator", "value", "string_value"} {
-				if _, ok := cond[key]; !ok {
-					cond[key] = nil
-				}
-			}
-			for _, key := range []string{"series_names", "series_names_except"} {
-				if _, ok := cond[key]; !ok {
-					cond[key] = []string{}
-				}
-			}
-		}
-	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)
@@ -77,7 +77,7 @@ func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 			if len(cond) != 3 || cond["alert_type"] != "threshold" || cond["operator"] != "lower_than" || cond["value"] != float64(10000) {
 				t.Fatalf("unexpected condition payload: %v", cond)
 			}
-			normalizeConditions(reqData)
+			normalizeConditions(t, reqData)
 			reqData["series_names"] = []string{}
 			reqData["series_names_except"] = []string{}
 			reqData["source_platforms"] = []string{}
@@ -110,7 +110,7 @@ func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 			if err = json.Unmarshal(body, &patchReq); err != nil {
 				t.Fatal(err)
 			}
-			normalizeConditions(patchReq)
+			normalizeConditions(t, patchReq)
 			patch := make(map[string]interface{})
 			if err = json.Unmarshal(alertData.Load().([]byte), &patch); err != nil {
 				t.Fatal(err)
@@ -244,6 +244,7 @@ func TestResourceDashboardAlertAdditionalConditions(t *testing.T) {
 // been created yet, so the raw config carries an unknown value at plan time. cty
 // panics on ElementIterator/LengthInt for those, so validateAlert must skip them.
 func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
+	var groupData atomic.Value
 	var alertData atomic.Value
 
 	// The API echoes every alert normalized to all keys; mirror enough of that so
@@ -258,19 +259,7 @@ func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
 				attrs[key] = []string{}
 			}
 		}
-		for _, item := range attrs["additional_conditions"].([]interface{}) {
-			cond := item.(map[string]interface{})
-			for _, key := range []string{"alert_type", "operator", "value", "string_value"} {
-				if _, ok := cond[key]; !ok {
-					cond[key] = nil
-				}
-			}
-			for _, key := range []string{"series_names", "series_names_except"} {
-				if _, ok := cond[key]; !ok {
-					cond[key] = []string{}
-				}
-			}
-		}
+		normalizeConditions(t, attrs)
 		out, err := json.Marshal(attrs)
 		if err != nil {
 			t.Fatal(err)
@@ -285,20 +274,25 @@ func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
 		}
 
+		groupPrefix := "/api/v1/source-groups"
+		groupID := "7"
 		alertPrefix := "/api/v2/dashboards/1/charts/10/alerts"
+		alertID := "100"
 
 		switch {
-		case r.Method == http.MethodPost && r.RequestURI == "/api/v1/source-groups":
+		case r.Method == http.MethodPost && r.RequestURI == groupPrefix:
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
+			groupData.Store(body)
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"7","attributes":%s}}`, body)))
-		case r.Method == http.MethodGet && r.RequestURI == "/api/v1/source-groups/7":
-			_, _ = w.Write([]byte(`{"data":{"id":"7","attributes":{"name":"Unknown series group"}}}`))
-		case r.Method == http.MethodDelete && r.RequestURI == "/api/v1/source-groups/7":
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, groupID, body)))
+		case r.Method == http.MethodGet && r.RequestURI == groupPrefix+"/"+groupID:
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, groupID, groupData.Load().([]byte))))
+		case r.Method == http.MethodDelete && r.RequestURI == groupPrefix+"/"+groupID:
 			w.WriteHeader(http.StatusNoContent)
+			groupData.Store([]byte(nil))
 
 		case r.Method == http.MethodPost && r.RequestURI == alertPrefix:
 			body, err := io.ReadAll(r.Body)
@@ -308,11 +302,12 @@ func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
 			body = normalizeAlert(body)
 			alertData.Store(body)
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"100","attributes":%s}}`, body)))
-		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/100":
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"100","attributes":%s}}`, alertData.Load().([]byte))))
-		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, alertPrefix+"/"):
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, body)))
+		case r.Method == http.MethodGet && r.RequestURI == alertPrefix+"/"+alertID:
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, alertID, alertData.Load().([]byte))))
+		case r.Method == http.MethodDelete && r.RequestURI == alertPrefix+"/"+alertID:
 			w.WriteHeader(http.StatusNoContent)
+			alertData.Store([]byte(nil))
 
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
@@ -348,12 +343,15 @@ func TestResourceDashboardAlertConditionsUnknownSeriesNames(t *testing.T) {
 					check_period = 300
 
 					additional_conditions {
-						alert_type   = "threshold"
-						operator     = "lower_than"
-						value        = 10000
+						alert_type = "threshold"
+						operator   = "lower_than"
+						value      = 10000
 						# Branches of differing length keep the whole list unknown at plan time
 						# (a same-length conditional would only leave the element unknown).
-						series_names = logtail_source_group.this.id == "7" ? ["production"] : ["production", "staging"]
+						series_names = logtail_source_group.this.id != "" ? ["production"] : ["production", "staging"]
+						# Set but empty, so the null shortcut cannot skip the pair check and the
+						# unknown series_names above reaches the length comparison.
+						series_names_except = []
 					}
 				}
 				`,


### PR DESCRIPTION
Fixes #133.

`terraform plan` crashes the plugin whenever an `additional_conditions` block's `series_names`/`series_names_except` is not known yet — e.g. derived from a resource that has not been applied. No token and no API call are involved; the panic happens inside `PlanResourceChange`.

`validateAlert` reached `ElementIterator`/`LengthInt` after only `IsNull` guards, and cty panics on unknown values for both. Unknown values are now skipped the way `ptr.go` already does it. Nothing is lost by skipping: Terraform re-runs the plan at apply time with everything known, so a condition that really does set both scope fields is still rejected — one phase later.

## Implementation notes

- `IsKnown` guards on the conditions list, each element, and each of the two scope lists, matching the `IsNull() || !IsKnown()` idiom used in `ptr.go`, `team_name.go`, and `userManagesDatabasesBlock`.
- The three separate `GetRawConfig()` lookups in `validateAlert` are folded into one guarded block.
- The check itself is unchanged for known values: both scopes must be non-null and non-empty to be an error.

## Testing

- `TestResourceDashboardAlertConditionsUnknownSeriesNames` reproduces the crash from the issue: a condition whose `series_names` comes from a conditional with differing-length branches, which keeps the whole list unknown at plan time. It panics against the unpatched provider.
- The condition also sets `series_names_except = []`. Without it the null shortcut returns before any `LengthInt` call and the test passes even with every `IsKnown` guard deleted — verified by removing them one at a time.
- Shared mock helper `normalizeConditions` instead of a second copy of its body, and the new mock follows the package conventions (ID locals, source-group reads echoing the stored POST body, exact-match DELETE).
- Full unit suite green.
