### PR TITLE
Expose AWS log-group subscription timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 10.18.0
+VERSION := 10.18.1
 .PHONY: test build
 
 help:

--- a/docs/resources/source_aws_log_group.md
+++ b/docs/resources/source_aws_log_group.md
@@ -43,4 +43,6 @@ resource "logtail_source_aws_log_group" "excluded" {
 
 ### Read-Only
 
+- `created_at` (String) The time when this log-group subscription override was created.
 - `id` (String) The ID of this resource.
+- `updated_at` (String) The time when this log-group subscription override was last updated.

--- a/internal/provider/resource_source_aws_log_group.go
+++ b/internal/provider/resource_source_aws_log_group.go
@@ -35,12 +35,24 @@ var sourceAWSLogGroupSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Default:     true,
 	},
+	"created_at": {
+		Description: "The time when this log-group subscription override was created.",
+		Type:        schema.TypeString,
+		Computed:    true,
+	},
+	"updated_at": {
+		Description: "The time when this log-group subscription override was last updated.",
+		Type:        schema.TypeString,
+		Computed:    true,
+	},
 }
 
 type sourceAWSLogGroup struct {
 	Region     string `json:"region"`
 	Name       string `json:"name"`
 	Subscribed bool   `json:"subscribed"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
 }
 
 type sourceAWSLogGroupHTTPResponse struct {
@@ -139,5 +151,11 @@ func sourceAWSLogGroupCopyAttrs(d *schema.ResourceData, in *sourceAWSLogGroup) d
 	if err := d.Set("name", in.Name); err != nil {
 		return diag.FromErr(err)
 	}
-	return diag.FromErr(d.Set("subscribed", in.Subscribed))
+	if err := d.Set("subscribed", in.Subscribed); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("created_at", in.CreatedAt); err != nil {
+		return diag.FromErr(err)
+	}
+	return diag.FromErr(d.Set("updated_at", in.UpdatedAt))
 }

--- a/internal/provider/resource_source_aws_log_group_test.go
+++ b/internal/provider/resource_source_aws_log_group_test.go
@@ -34,6 +34,11 @@ func TestResourceSourceAWSLogGroup(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if strings.Contains(string(body), `"created_at"`) || strings.Contains(string(body), `"updated_at"`) {
+				t.Fatalf("POST body must omit read-only timestamps, got: %s", body)
+			}
+			body = inject(t, body, "created_at", "2026-08-18T10:00:00.000Z")
+			body = inject(t, body, "updated_at", "2026-08-18T10:00:00.000Z")
 			attributes.Store(body)
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":"7","attributes":%s}}`, body)))
@@ -100,6 +105,8 @@ func TestResourceSourceAWSLogGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("logtail_source_aws_log_group.api", "region", "us-east-1"),
 					resource.TestCheckResourceAttr("logtail_source_aws_log_group.api", "name", "/aws/lambda/api"),
 					resource.TestCheckResourceAttr("logtail_source_aws_log_group.api", "subscribed", "true"),
+					resource.TestCheckResourceAttr("logtail_source_aws_log_group.api", "created_at", "2026-08-18T10:00:00.000Z"),
+					resource.TestCheckResourceAttr("logtail_source_aws_log_group.api", "updated_at", "2026-08-18T10:00:00.000Z"),
 				),
 			},
 			{


### PR DESCRIPTION
## Summary
- expose the AWS log-group subscription API's `created_at` and `updated_at` fields as read-only resource attributes
- bump the intended provider release to 10.18.1
- regenerate the resource documentation

## Verification
- `go test ./internal/provider -run '^TestResourceSourceAWSLogGroup$' -count=1`
- `make test`
- `make fmt`
- `make gen`